### PR TITLE
Update result return type in unit-test

### DIFF
--- a/test/unit-test/twcc_manager/twcc_manager_utest.c
+++ b/test/unit-test/twcc_manager/twcc_manager_utest.c
@@ -26,7 +26,7 @@ void test_twccAddPacket( void )
     uint16_t seqNum = 256;
     uint32_t i;
     RtcpTwccManager_t twccManager;
-    RtcpResult_t result;
+    RtcpTwccManagerResult_t result;
     TwccPacketInfo_t twccPacketInfo = { 0 };
 
     result = RtcpTwccManager_Init( &( twccManager ),
@@ -64,7 +64,7 @@ void test_twccOlderPacketInfoDeletion( void )
     uint16_t seqNum = 256;
     uint32_t i;
     RtcpTwccManager_t twccManager;
-    RtcpResult_t result;
+    RtcpTwccManagerResult_t result;
     TwccPacketInfo_t twccPacketInfo = { 0 };
     TwccPacketInfo_t foundTwccPacketInfo;
 
@@ -124,7 +124,7 @@ void test_twccFindPacket_NotFound( void )
     uint16_t seqNum = 256;
     uint32_t i;
     RtcpTwccManager_t twccManager;
-    RtcpResult_t result;
+    RtcpTwccManagerResult_t result;
     TwccPacketInfo_t twccPacketInfo = { 0 };
 
     result = RtcpTwccManager_Init( &( twccManager ),
@@ -160,7 +160,7 @@ void test_twccFindPacket_Found( void )
     uint16_t seqNum = 256;
     uint32_t i;
     RtcpTwccManager_t twccManager;
-    RtcpResult_t result;
+    RtcpTwccManagerResult_t result;
     TwccPacketInfo_t twccPacketInfo = { 0 };
     uint64_t localSentTime = time( NULL );
 


### PR DESCRIPTION
Description
-----------
The variable type of **result** in the twcc_manager_utest.c for the tests was changed from _RtcpResult_t_ to _RtcpTwccManagerResult_t_.

Test Steps
-----------
The following unit-tests are being validated after this commit changes. 
* _test_twccAddPacket_  -- ( Validate Twcc Manager Add packet functionality ) 
* _test_twccOlderPacketInfoDeletion_ -- ( Validate Twcc Manager check Older packet deletion functionality ) 
* _test_twccOlderPacketInfoDeletion_ -- ( Validate Twcc Manager check Older packet deletion functionality ) 
* _test_twccFindPacket_NotFound_  -- ( Validate Twcc Manager Find packet functionality ) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
