### PR TITLE
Make coverage target work on Linux and Mac 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "test/CMock"]
 	path = test/CMock
-	url = git@github.com:ThrowTheSwitch/CMock.git
+	url = https://github.com/ThrowTheSwitch/CMock.git
 	update = none

--- a/README.md
+++ b/README.md
@@ -112,20 +112,10 @@ git submodule update --checkout --init --recursive test/CMock
 ### Steps to Generate Code Coverage Report
 
 1. Run Unit Tests in [Steps to Build and Run Unit Tests](#steps-to-build-and-run-unit-tests).
-2. Generate coverage.info in the `build` folder:
+2. Generate coverage report in the `build/coverage` folder:
 
     ```
     make coverage
-    ```
-3. Get code coverage by `lcov`:
-
-    ```
-    lcov --rc lcov_branch_coverage=1 -r coverage.info -o coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
-    ```
-4. Generage HTML report in the folder `CodecovHTMLReport`:
-
-    ```
-    genhtml --rc lcov_branch_coverage=1 --ignore-errors source coverage.info --legend --output-directory=CodecovHTMLReport
     ```
 
 ### Script to Run Unit Test and Generate Code Coverage Report
@@ -137,8 +127,6 @@ make -C build all
 cd build
 ctest -E system --output-on-failure
 make coverage
-lcov --rc lcov_branch_coverage=1 -r coverage.info -o coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
-genhtml --rc lcov_branch_coverage=1 --ignore-errors source coverage.info --legend --output-directory=CodecovHTMLReport
 ```
 
 ## Security

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -15,9 +15,9 @@ execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
                          --base-directory ${CMAKE_BINARY_DIR}
                          --initial
                          --capture
-                         --rc lcov_branch_coverage=1
-                         --rc genhtml_branch_coverage=1
+                         --rc branch_coverage=1
                          --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
+                         --include "*source*"
         )
 file(GLOB files "${CMAKE_BINARY_DIR}/bin/tests/*")
 
@@ -47,11 +47,11 @@ execute_process(COMMAND ruby
 # Capture data after running the tests.
 execute_process(
             COMMAND lcov --capture
-                         --rc lcov_branch_coverage=1
-                         --rc genhtml_branch_coverage=1
+                         --rc branch_coverage=1
                          --base-directory ${CMAKE_BINARY_DIR}
                          --directory ${CMAKE_BINARY_DIR}
                          --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
+                         --include "*source*"
         )
 
 # Combile baseline results (zeros) with the one after running the tests.
@@ -61,12 +61,12 @@ execute_process(
                          --add-tracefile ${CMAKE_BINARY_DIR}/base_coverage.info
                          --add-tracefile ${CMAKE_BINARY_DIR}/second_coverage.info
                          --output-file ${CMAKE_BINARY_DIR}/coverage.info
-                         --no-external
-                         --rc lcov_branch_coverage=1
+                         --rc branch_coverage=1
+                         --include "*source*"
         )
 execute_process(
-            COMMAND genhtml --rc lcov_branch_coverage=1
+            COMMAND genhtml --rc branch_coverage=1
                             --branch-coverage
                             --output-directory ${CMAKE_BINARY_DIR}/coverage
-                                ${CMAKE_BINARY_DIR}/coverage.info
+                            ${CMAKE_BINARY_DIR}/coverage.info
         )

--- a/test/unit-test/cmock/create_test.cmake
+++ b/test/unit-test/cmock/create_test.cmake
@@ -127,10 +127,20 @@ function(create_mock_list mock_name
                                ${mocks_dir}
                                ${mock_include_list}
            )
-    set_target_properties(${mock_name} PROPERTIES
-                        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
-                        POSITION_INDEPENDENT_CODE ON
-            )
+
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        set_target_properties(${mock_name} PROPERTIES
+                              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                              POSITION_INDEPENDENT_CODE ON
+                              LINK_FLAGS "-Wl,-undefined,dynamic_lookup"
+                             )
+    else()
+        set_target_properties(${mock_name} PROPERTIES
+                              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                              POSITION_INDEPENDENT_CODE ON
+                             )
+    endif()
+
     target_compile_definitions(${mock_name} PUBLIC
             ${mock_define_list}
         )

--- a/test/unit-test/cmock/create_test.cmake
+++ b/test/unit-test/cmock/create_test.cmake
@@ -20,9 +20,6 @@ function(create_test test_name
             COMPILE_FLAG "-O0 -ggdb"
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/tests"
             INSTALL_RPATH_USE_LINK_PATH TRUE
-            LINK_FLAGS " \
-                -Wl,-rpath,${CMAKE_BINARY_DIR}/lib \
-                -Wl,-rpath,${CMAKE_CURRENT_BINARY_DIR}/lib"
         )
     target_include_directories(${test_name} PUBLIC
                                ${mocks_dir}
@@ -43,7 +40,7 @@ function(create_test test_name
         add_dependencies(${test_name} ${dependency})
         target_link_libraries(${test_name} ${dependency})
     endforeach()
-    target_link_libraries(${test_name} -lgcov unity)
+    target_link_libraries(${test_name} unity)
     target_link_directories(${test_name}  PUBLIC
                             ${CMAKE_CURRENT_BINARY_DIR}/lib
             )
@@ -170,7 +167,6 @@ function(create_real_library target
         add_dependencies(${target} ${mock_name})
         target_link_libraries(${target}
                         -l${mock_name}
-                        -lgcov
                 )
     endif()
 endfunction()

--- a/test/unit-test/twcc_manager/ut.cmake
+++ b/test/unit-test/twcc_manager/ut.cmake
@@ -66,7 +66,7 @@ create_real_library(${real_name}
         )
 
 list(APPEND utest_link_list
-            -l${mock_name}
+            # -l${mock_name}
             lib${real_name}.a
         )
 


### PR DESCRIPTION
## Description of changes

`make coverage` was not working correctly on latest Ubuntu (24.04) and on Mac. This PR makes it work on both Ubuntu (24.04) and on Mac.

## Test Steps
```
git submodule update --init --recursive --checkout test/CMock
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
