### PR TITLE
Make branch coverage work with old version of lcov

### DIFF
--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -15,7 +15,7 @@ execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
                          --base-directory ${CMAKE_BINARY_DIR}
                          --initial
                          --capture
-                         --rc branch_coverage=1
+                         --rc lcov_branch_coverage=1
                          --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
                          --include "*source*"
         )
@@ -47,7 +47,7 @@ execute_process(COMMAND ruby
 # Capture data after running the tests.
 execute_process(
             COMMAND lcov --capture
-                         --rc branch_coverage=1
+                         --rc lcov_branch_coverage=1
                          --base-directory ${CMAKE_BINARY_DIR}
                          --directory ${CMAKE_BINARY_DIR}
                          --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
@@ -61,11 +61,11 @@ execute_process(
                          --add-tracefile ${CMAKE_BINARY_DIR}/base_coverage.info
                          --add-tracefile ${CMAKE_BINARY_DIR}/second_coverage.info
                          --output-file ${CMAKE_BINARY_DIR}/coverage.info
-                         --rc branch_coverage=1
+                         --rc lcov_branch_coverage=1
                          --include "*source*"
         )
 execute_process(
-            COMMAND genhtml --rc branch_coverage=1
+            COMMAND genhtml --rc lcov_branch_coverage=1
                             --branch-coverage
                             --output-directory ${CMAKE_BINARY_DIR}/coverage
                             ${CMAKE_BINARY_DIR}/coverage.info


### PR DESCRIPTION
Description
------------
lcov before version 2 used `--rc lcov_branch_coverage=1` to enable branch coverage which is deprecated in version 2 in favour of `--rc branch_coverage=1`. This commit reverts to using `--rc lcov_branch_coverage=1` to ensure that branch coverage works with both old and new lcov.

Testing
--------
```
git submodule update --init --recursive --checkout test/CMock
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
