### PR TITLE
Improve readability of create_test.cmake

### DIFF
--- a/test/unit-test/cmock/create_test.cmake
+++ b/test/unit-test/cmock/create_test.cmake
@@ -125,7 +125,7 @@ function(create_mock_list mock_name
                                ${mock_include_list}
            )
 
-    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    if (APPLE)
         set_target_properties(${mock_name} PROPERTIES
                               LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
                               POSITION_INDEPENDENT_CODE ON


### PR DESCRIPTION
### Description of changes:*

This PR is for improving the code readability by substituting` if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")` to `if(APPLE)`

### Test Steps

```
git submodule update --init --recursive --checkout test/CMock
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
