### PR TITLE
Completion of RTCP UTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ git submodule update --checkout --init --recursive test/CMock
 
 ```sh
 git submodule update --init --recursive --checkout test/CMock
-cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
+cmake -S test/unit-test -B build/ -G "Unix Makefiles"  -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
 make -C build all
 cd build
 ctest -E system --output-on-failure

--- a/source/rtcp_api.c
+++ b/source/rtcp_api.c
@@ -188,31 +188,31 @@
 #define RTCP_TWCC_PACKET_STATUS_SMALL_DELTA            1
 #define RTCP_TWCC_PACKET_STATUS_LARGE_DELTA            2
 
-#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_TYPE( packetChunk )          \
-        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_TYPE_BITMASK ) >> \
+#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_TYPE( packetChunk )              \
+        ( ( ( packetChunk ) & RTCP_TWCC_PACKET_CHUNK_TYPE_BITMASK ) >>  \
           RTCP_TWCC_PACKET_CHUNK_TYPE_LOCATION )
 
-#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_STATUS( packetChunk )            \
-        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_STATUS_BITMASK ) >>   \
+#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_STATUS( packetChunk )                \
+        ( ( ( packetChunk ) & RTCP_TWCC_PACKET_CHUNK_STATUS_BITMASK ) >>    \
           RTCP_TWCC_PACKET_CHUNK_STATUS_LOCATION )
 
-#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_RUN_LENGTH( packetChunk )            \
-        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_BITMASK ) >>   \
+#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_RUN_LENGTH( packetChunk )                \
+        ( ( ( packetChunk ) & RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_BITMASK ) >>    \
           RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_LOCATION )
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_SIZE( packetChunk )   \
-        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK ) == 0 ? 1 : 2 )
+        ( ( ( packetChunk ) & RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK ) == 0 ? 1 : 2 )
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_COUNT( packetChunk )   \
-        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK ) == 0 ? 14 : 7 )
+        ( ( ( packetChunk ) & RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK ) == 0 ? 14 : 7 )
 
-#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_LIST( packetChunk )           \
-        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_BITMASK ) >>  \
+#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_LIST( packetChunk )               \
+        ( ( ( packetChunk ) & RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_BITMASK ) >>   \
           RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_LOCATION )
 
-#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_FROM_LIST( symbolList, i, symbolSize )                \
+#define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_FROM_LIST( symbolList, i, symbolSize )                    \
         ( ( symbolSize ) == 1 ? ( ( ( symbolList ) >> ( 14 - ( ( i + 1 ) * ( symbolSize ) ) ) ) & 1 )   \
-                          : ( ( ( symbolList ) >> ( 14 - ( ( i + 1 ) * ( symbolSize ) ) ) ) & 3 ) )
+                              : ( ( ( symbolList ) >> ( 14 - ( ( i + 1 ) * ( symbolSize ) ) ) ) & 3 ) )
 
 #define RTCP_TWCC_MS_TO_HUNDRED_OF_NANOS( ms )  \
         ( ( ( ms ) * RTCP_TWCC_HUNDREDS_OF_NANOS_IN_A_SECOND ) / 1000 )
@@ -230,24 +230,28 @@ static RtcpPacketType_t GetRtcpPacketType( uint8_t packetType,
     switch( packetType )
     {
         case RTCP_PACKET_TYPE_FIR:
-
+        {
             if( fmt == 0 )
             {
                 ret = RTCP_PACKET_FIR;
             }
-
-            break;
+        }
+        break;
 
         case RTCP_PACKET_TYPE_SENDER_REPORT:
+        {
             ret = RTCP_PACKET_SENDER_REPORT;
-            break;
+        }
+        break;
 
         case RTCP_PACKET_TYPE_RECEIVER_REPORT:
+        {
             ret = RTCP_PACKET_RECEIVER_REPORT;
-            break;
+        }
+        break;
 
         case RTCP_PACKET_TYPE_TRANSPORT_SPECIFIC_FEEDBACK:
-
+        {
             if( fmt == RTCP_FMT_TRANSPORT_SPECIFIC_FEEDBACK_NACK )
             {
                 ret = RTCP_PACKET_TRANSPORT_FEEDBACK_NACK;
@@ -256,11 +260,11 @@ static RtcpPacketType_t GetRtcpPacketType( uint8_t packetType,
             {
                 ret = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
             }
-
-            break;
+        }
+        break;
 
         case RTCP_PACKET_TYPE_PAYLOAD_SPECIFIC_FEEDBACK:
-
+        {
             if( fmt == RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_PLI )
             {
                 ret = RTCP_PACKET_PAYLOAD_FEEDBACK_PLI;
@@ -273,8 +277,8 @@ static RtcpPacketType_t GetRtcpPacketType( uint8_t packetType,
             {
                 ret = RTCP_PACKET_PAYLOAD_FEEDBACK_REMB;
             }
-
-            break;
+        }
+        break;
     }
 
     return ret;
@@ -428,11 +432,13 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                 switch( statusSymbol )
                 {
                     case RTCP_TWCC_PACKET_STATUS_NOT_RECEIVED:
+                    {
                         remoteArrivalTime = RTCP_TWCC_PACKET_LOST_TIME;
-                        break;
+                    }
+                    break;
 
                     case RTCP_TWCC_PACKET_STATUS_SMALL_DELTA:
-
+                    {
                         if( currentReceiveDeltaIndex < pRtcpPacket->payloadLength )
                         {
                             recvDelta = ( uint16_t ) ( pRtcpPacket->pPayload[ currentReceiveDeltaIndex ] );
@@ -445,11 +451,11 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                         {
                             result = RTCP_RESULT_MALFORMED_PACKET;
                         }
-
-                        break;
+                    }
+                    break;
 
                     case RTCP_TWCC_PACKET_STATUS_LARGE_DELTA:
-
+                    {
                         if( ( currentReceiveDeltaIndex + 1 ) < pRtcpPacket->payloadLength )
                         {
                             recvDelta = RTCP_READ_UINT16( &( pRtcpPacket->pPayload[ currentReceiveDeltaIndex ] ) );
@@ -462,8 +468,8 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                         {
                             result = RTCP_RESULT_MALFORMED_PACKET;
                         }
-
-                        break;
+                    }
+                    break;
                 }
 
                 if( pTwccPacket->pArrivalInfoList != NULL )
@@ -502,11 +508,13 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                 switch( statusSymbol )
                 {
                     case RTCP_TWCC_PACKET_STATUS_NOT_RECEIVED:
+                    {
                         remoteArrivalTime = RTCP_TWCC_PACKET_LOST_TIME;
-                        break;
+                    }
+                    break;
 
                     case RTCP_TWCC_PACKET_STATUS_SMALL_DELTA:
-
+                    {
                         if( currentReceiveDeltaIndex < pRtcpPacket->payloadLength )
                         {
                             recvDelta = ( uint16_t ) ( pRtcpPacket->pPayload[ currentReceiveDeltaIndex ] );
@@ -519,11 +527,11 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                         {
                             result = RTCP_RESULT_MALFORMED_PACKET;
                         }
-
-                        break;
+                    }
+                    break;
 
                     case RTCP_TWCC_PACKET_STATUS_LARGE_DELTA:
-
+                    {
                         if( ( currentReceiveDeltaIndex + 1 ) < pRtcpPacket->payloadLength )
                         {
                             recvDelta = RTCP_READ_UINT16( &( pRtcpPacket->pPayload[ currentReceiveDeltaIndex ] ) );
@@ -536,8 +544,8 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                         {
                             result = RTCP_RESULT_MALFORMED_PACKET;
                         }
-
-                        break;
+                    }
+                    break;
                 }
 
                 if( pTwccPacket->pArrivalInfoList != NULL )
@@ -795,7 +803,10 @@ RtcpResult_t Rtcp_DeserializePacket( RtcpContext_t * pCtx,
         {
             result = RTCP_RESULT_MALFORMED_PACKET;
         }
+    }
 
+    if( result == RTCP_RESULT_OK )
+    {
         pRtcpPacket->header.padding = ( firstWord & RTCP_HEADER_PADDING_BITMASK ) >>
                                       RTCP_HEADER_PADDING_LOCATION;
 

--- a/source/rtcp_api.c
+++ b/source/rtcp_api.c
@@ -10,18 +10,18 @@
 /*
  * Helper macros.
  */
-#define RTCP_WRITE_UINT16   ( pCtx->readWriteFunctions.writeUint16Fn )
-#define RTCP_WRITE_UINT32   ( pCtx->readWriteFunctions.writeUint32Fn )
-#define RTCP_WRITE_UINT64   ( pCtx->readWriteFunctions.writeUint64Fn )
-#define RTCP_READ_UINT16    ( pCtx->readWriteFunctions.readUint16Fn )
-#define RTCP_READ_UINT32    ( pCtx->readWriteFunctions.readUint32Fn )
-#define RTCP_READ_UINT64    ( pCtx->readWriteFunctions.readUint64Fn )
+#define RTCP_WRITE_UINT16    ( pCtx->readWriteFunctions.writeUint16Fn )
+#define RTCP_WRITE_UINT32    ( pCtx->readWriteFunctions.writeUint32Fn )
+#define RTCP_WRITE_UINT64    ( pCtx->readWriteFunctions.writeUint64Fn )
+#define RTCP_READ_UINT16     ( pCtx->readWriteFunctions.readUint16Fn )
+#define RTCP_READ_UINT32     ( pCtx->readWriteFunctions.readUint32Fn )
+#define RTCP_READ_UINT64     ( pCtx->readWriteFunctions.readUint64Fn )
 
 #define RTCP_BYTES_TO_WORDS( bytes )    \
-    ( ( bytes ) / 4 )
+        ( ( bytes ) / 4 )
 
 #define RTCP_WORDS_TO_BYTES( words )    \
-    ( ( words ) * 4 )
+        ( ( words ) * 4 )
 
 /*-----------------------------------------------------------*/
 
@@ -35,12 +35,12 @@
 #define RTCP_PACKET_TYPE_TRANSPORT_SPECIFIC_FEEDBACK    205 /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.2 */
 #define RTCP_PACKET_TYPE_PAYLOAD_SPECIFIC_FEEDBACK      206 /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.3 */
 
-#define RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_PLI      1  /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.3 */
-#define RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_SLI      2  /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.3 */
-#define RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_RPSI     3  /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.3 */
-#define RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_REMB     15 /* https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03#section-2.2 */
-#define RTCP_FMT_TRANSPORT_SPECIFIC_FEEDBACK_NACK   1  /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.2.1 */
-#define RTCP_FMT_TRANSPORT_SPECIFIC_FEEDBACK_TWCC   15 /* https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#section-3.1 */
+#define RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_PLI          1   /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.3 */
+#define RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_SLI          2   /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.3 */
+#define RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_RPSI         3   /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.3 */
+#define RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_REMB         15  /* https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03#section-2.2 */
+#define RTCP_FMT_TRANSPORT_SPECIFIC_FEEDBACK_NACK       1   /* https://datatracker.ietf.org/doc/html/rfc4585#section-6.2.1 */
+#define RTCP_FMT_TRANSPORT_SPECIFIC_FEEDBACK_TWCC       15  /* https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#section-3.1 */
 
 /*-----------------------------------------------------------*/
 
@@ -52,23 +52,23 @@
  * |V=2|P|    FMT     |       PT      |             length         |
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  */
-#define RTCP_HEADER_LENGTH                      4
-#define RTCP_HEADER_VERSION                     2
+#define RTCP_HEADER_LENGTH                    4
+#define RTCP_HEADER_VERSION                   2
 
-#define RTCP_HEADER_VERSION_BITMASK             0xC0000000
-#define RTCP_HEADER_VERSION_LOCATION            30
+#define RTCP_HEADER_VERSION_BITMASK           0xC0000000
+#define RTCP_HEADER_VERSION_LOCATION          30
 
-#define RTCP_HEADER_PADDING_BITMASK             0x20000000
-#define RTCP_HEADER_PADDING_LOCATION            29
+#define RTCP_HEADER_PADDING_BITMASK           0x20000000
+#define RTCP_HEADER_PADDING_LOCATION          29
 
-#define RTCP_HEADER_RC_BITMASK                  0x1F000000
-#define RTCP_HEADER_RC_LOCATION                 24
+#define RTCP_HEADER_RC_BITMASK                0x1F000000
+#define RTCP_HEADER_RC_LOCATION               24
 
-#define RTCP_HEADER_PACKET_TYPE_BITMASK         0x00FF0000
-#define RTCP_HEADER_PACKET_TYPE_LOCATION        16
+#define RTCP_HEADER_PACKET_TYPE_BITMASK       0x00FF0000
+#define RTCP_HEADER_PACKET_TYPE_LOCATION      16
 
-#define RTCP_HEADER_PACKET_LENGTH_BITMASK       0x0000FFFF
-#define RTCP_HEADER_PACKET_LENGTH_LOCATION      0
+#define RTCP_HEADER_PACKET_LENGTH_BITMASK     0x0000FFFF
+#define RTCP_HEADER_PACKET_LENGTH_LOCATION    0
 
 /*-----------------------------------------------------------*/
 
@@ -98,8 +98,8 @@
  *
  * RFC - https://datatracker.ietf.org/doc/html/rfc2032#section-5.2.1
  */
-#define RTCP_FIR_PACKET_PAYLOAD_LENGTH          4
-#define RTCP_FIR_PACKET_SENDER_SSRC_OFFSET      0
+#define RTCP_FIR_PACKET_PAYLOAD_LENGTH        4
+#define RTCP_FIR_PACKET_SENDER_SSRC_OFFSET    0
 
 /*-----------------------------------------------------------*/
 
@@ -108,9 +108,9 @@
  *
  * RFC - https://datatracker.ietf.org/doc/html/rfc4585#section-6.3.1
  */
-#define RTCP_PLI_PACKET_PAYLOAD_LENGTH          8
-#define RTCP_PLI_PACKET_SENDER_SSRC_OFFSET      0
-#define RTCP_PLI_PACKET_MEDIA_SSRC_OFFSET       4
+#define RTCP_PLI_PACKET_PAYLOAD_LENGTH        8
+#define RTCP_PLI_PACKET_SENDER_SSRC_OFFSET    0
+#define RTCP_PLI_PACKET_MEDIA_SSRC_OFFSET     4
 
 /*-----------------------------------------------------------*/
 
@@ -119,7 +119,7 @@
  *
  * RFC - https://datatracker.ietf.org/doc/html/rfc4585#section-6.3.2
  */
-#define RTCP_SLI_PACKET_MIN_PAYLOAD_LENGTH      12
+#define RTCP_SLI_PACKET_MIN_PAYLOAD_LENGTH    12
 
 /*-----------------------------------------------------------*/
 
@@ -128,19 +128,19 @@
  *
  * RFC - https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03#section-2.2
  */
-#define RTCP_REMB_PACKET_MIN_PAYLOAD_LENGTH     20
-#define RTCP_REMB_PACKET_IDENTIFIER_OFFSET      8
-#define RTCP_REMB_PACKET_IDENTIFIER_LENGTH      4
-#define RTCP_REMB_PACKET_NUM_SSRC_OFFSET        12
+#define RTCP_REMB_PACKET_MIN_PAYLOAD_LENGTH      20
+#define RTCP_REMB_PACKET_IDENTIFIER_OFFSET       8
+#define RTCP_REMB_PACKET_IDENTIFIER_LENGTH       4
+#define RTCP_REMB_PACKET_NUM_SSRC_OFFSET         12
 
-#define RTCP_REMB_PACKET_NUM_SSRC_BITMASK       0xFF000000
-#define RTCP_REMB_PACKET_NUM_SSRC_LOCATION      24
+#define RTCP_REMB_PACKET_NUM_SSRC_BITMASK        0xFF000000
+#define RTCP_REMB_PACKET_NUM_SSRC_LOCATION       24
 
-#define RTCP_REMB_PACKET_BR_EXPONENT_BITMASK    0x00FC0000
-#define RTCP_REMB_PACKET_BR_EXPONENT_LOCATION   18
+#define RTCP_REMB_PACKET_BR_EXPONENT_BITMASK     0x00FC0000
+#define RTCP_REMB_PACKET_BR_EXPONENT_LOCATION    18
 
-#define RTCP_REMB_PACKET_BR_MANTISSA_BITMASK    0x0003FFFF
-#define RTCP_REMB_PACKET_BR_MANTISSA_LOCATION   0
+#define RTCP_REMB_PACKET_BR_MANTISSA_BITMASK     0x0003FFFF
+#define RTCP_REMB_PACKET_BR_MANTISSA_LOCATION    0
 
 /*-----------------------------------------------------------*/
 
@@ -149,7 +149,7 @@
  *
  * RFC - https://datatracker.ietf.org/doc/html/rfc4585#section-6.2.1
  */
-#define RTCP_NACK_PACKET_MIN_PAYLOAD_LENGTH     12
+#define RTCP_NACK_PACKET_MIN_PAYLOAD_LENGTH    12
 
 /*-----------------------------------------------------------*/
 
@@ -158,67 +158,67 @@
  *
  * RFC - https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#section-3.1
  */
-#define RTCP_TWCC_PACKET_MIN_PAYLOAD_LENGTH         18
+#define RTCP_TWCC_PACKET_MIN_PAYLOAD_LENGTH            18
 
-#define RTCP_TWCC_REFERENCE_TIME_BITMASK            0xFFFFFF00
-#define RTCP_TWCC_REFERENCE_TIME_LOCATION           8
+#define RTCP_TWCC_REFERENCE_TIME_BITMASK               0xFFFFFF00
+#define RTCP_TWCC_REFERENCE_TIME_LOCATION              8
 
-#define RTCP_TWCC_FEEDBACK_PACKET_COUNT_BITMASK     0x000000FF
-#define RTCP_TWCC_FEEDBACK_PACKET_COUNT_LOCATION    0
+#define RTCP_TWCC_FEEDBACK_PACKET_COUNT_BITMASK        0x000000FF
+#define RTCP_TWCC_FEEDBACK_PACKET_COUNT_LOCATION       0
 
-#define RTCP_TWCC_PACKET_CHUNK_TYPE_BITMASK         0x8000
-#define RTCP_TWCC_PACKET_CHUNK_TYPE_LOCATION        15
+#define RTCP_TWCC_PACKET_CHUNK_TYPE_BITMASK            0x8000
+#define RTCP_TWCC_PACKET_CHUNK_TYPE_LOCATION           15
 
-#define RTCP_TWCC_PACKET_CHUNK_STATUS_BITMASK       0x6000
-#define RTCP_TWCC_PACKET_CHUNK_STATUS_LOCATION      13
+#define RTCP_TWCC_PACKET_CHUNK_STATUS_BITMASK          0x6000
+#define RTCP_TWCC_PACKET_CHUNK_STATUS_LOCATION         13
 
-#define RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_BITMASK   0x1FFF
-#define RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_LOCATION  0
+#define RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_BITMASK      0x1FFF
+#define RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_LOCATION     0
 
-#define RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK  0x4000
-#define RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_LOCATION 14
+#define RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK     0x4000
+#define RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_LOCATION    14
 
-#define RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_BITMASK  0x3FFF
-#define RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_LOCATION 0
+#define RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_BITMASK     0x3FFF
+#define RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_LOCATION    0
 
-#define RTCP_TWCC_PACKET_CHUNK_TYPE_RUN_LENGTH      0
-#define RTCP_TWCC_PACKET_CHUNK_TYPE_STATUS_VECTOR   1
+#define RTCP_TWCC_PACKET_CHUNK_TYPE_RUN_LENGTH         0
+#define RTCP_TWCC_PACKET_CHUNK_TYPE_STATUS_VECTOR      1
 
-#define RTCP_TWCC_PACKET_STATUS_NOT_RECEIVED        0
-#define RTCP_TWCC_PACKET_STATUS_SMALL_DELTA         1
-#define RTCP_TWCC_PACKET_STATUS_LARGE_DELTA         2
+#define RTCP_TWCC_PACKET_STATUS_NOT_RECEIVED           0
+#define RTCP_TWCC_PACKET_STATUS_SMALL_DELTA            1
+#define RTCP_TWCC_PACKET_STATUS_LARGE_DELTA            2
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_TYPE( packetChunk )          \
-    ( ( ( packetChunk ) &  RTCP_TWCC_PACKET_CHUNK_TYPE_BITMASK ) >> \
-      RTCP_TWCC_PACKET_CHUNK_TYPE_LOCATION )
+        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_TYPE_BITMASK ) >> \
+          RTCP_TWCC_PACKET_CHUNK_TYPE_LOCATION )
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_STATUS( packetChunk )            \
-    ( ( ( packetChunk ) &  RTCP_TWCC_PACKET_CHUNK_STATUS_BITMASK ) >>   \
-      RTCP_TWCC_PACKET_CHUNK_STATUS_LOCATION )
+        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_STATUS_BITMASK ) >>   \
+          RTCP_TWCC_PACKET_CHUNK_STATUS_LOCATION )
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_RUN_LENGTH( packetChunk )            \
-    ( ( ( packetChunk ) &  RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_BITMASK ) >>   \
-      RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_LOCATION )
+        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_BITMASK ) >>   \
+          RTCP_TWCC_PACKET_CHUNK_RUN_LENGTH_LOCATION )
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_SIZE( packetChunk )   \
-    ( ( ( packetChunk ) &  RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK ) == 0 ? 1 : 2 )
+        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK ) == 0 ? 1 : 2 )
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_COUNT( packetChunk )   \
-    ( ( ( packetChunk ) &  RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK ) == 0 ? 14 : 7 )
+        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_SYMBOL_SIZE_BITMASK ) == 0 ? 14 : 7 )
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_LIST( packetChunk )           \
-    ( ( ( packetChunk ) &  RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_BITMASK ) >>  \
-      RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_LOCATION )
+        ( ( ( packetChunk )&RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_BITMASK ) >>  \
+          RTCP_TWCC_PACKET_CHUNK_SYMBOL_LIST_LOCATION )
 
 #define RTCP_TWCC_PACKET_CHUNK_EXTRACT_SYMBOL_FROM_LIST( symbolList, i, symbolSize )                \
-    ( ( symbolSize ) == 1 ? ( ( ( symbolList ) >> ( 14 - ( ( i + 1 ) * ( symbolSize ) ) ) ) & 1 )   \
+        ( ( symbolSize ) == 1 ? ( ( ( symbolList ) >> ( 14 - ( ( i + 1 ) * ( symbolSize ) ) ) ) & 1 )   \
                           : ( ( ( symbolList ) >> ( 14 - ( ( i + 1 ) * ( symbolSize ) ) ) ) & 3 ) )
 
 #define RTCP_TWCC_MS_TO_HUNDRED_OF_NANOS( ms )  \
-    ( ( ( ms ) * RTCP_TWCC_HUNDREDS_OF_NANOS_IN_A_SECOND ) / 1000 )
+        ( ( ( ms ) * RTCP_TWCC_HUNDREDS_OF_NANOS_IN_A_SECOND ) / 1000 )
 
 #define RTCP_TWCC_US_TO_HUNDRED_OF_NANOS( us )  \
-    ( ( ( us ) * RTCP_TWCC_HUNDREDS_OF_NANOS_IN_A_SECOND ) / 1000000 )
+        ( ( ( us ) * RTCP_TWCC_HUNDREDS_OF_NANOS_IN_A_SECOND ) / 1000000 )
 
 /*-----------------------------------------------------------*/
 
@@ -230,28 +230,24 @@ static RtcpPacketType_t GetRtcpPacketType( uint8_t packetType,
     switch( packetType )
     {
         case RTCP_PACKET_TYPE_FIR:
-        {
+
             if( fmt == 0 )
             {
                 ret = RTCP_PACKET_FIR;
             }
-        }
-        break;
+
+            break;
 
         case RTCP_PACKET_TYPE_SENDER_REPORT:
-        {
             ret = RTCP_PACKET_SENDER_REPORT;
-        }
-        break;
+            break;
 
         case RTCP_PACKET_TYPE_RECEIVER_REPORT:
-        {
             ret = RTCP_PACKET_RECEIVER_REPORT;
-        }
-        break;
+            break;
 
         case RTCP_PACKET_TYPE_TRANSPORT_SPECIFIC_FEEDBACK:
-        {
+
             if( fmt == RTCP_FMT_TRANSPORT_SPECIFIC_FEEDBACK_NACK )
             {
                 ret = RTCP_PACKET_TRANSPORT_FEEDBACK_NACK;
@@ -260,11 +256,11 @@ static RtcpPacketType_t GetRtcpPacketType( uint8_t packetType,
             {
                 ret = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
             }
-        }
-        break;
+
+            break;
 
         case RTCP_PACKET_TYPE_PAYLOAD_SPECIFIC_FEEDBACK:
-        {
+
             if( fmt == RTCP_FMT_PAYLOAD_SPECIFIC_FEEDBACK_PLI )
             {
                 ret = RTCP_PACKET_PAYLOAD_FEEDBACK_PLI;
@@ -277,8 +273,8 @@ static RtcpPacketType_t GetRtcpPacketType( uint8_t packetType,
             {
                 ret = RTCP_PACKET_PAYLOAD_FEEDBACK_REMB;
             }
-        }
-        break;
+
+            break;
     }
 
     return ret;
@@ -432,13 +428,11 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                 switch( statusSymbol )
                 {
                     case RTCP_TWCC_PACKET_STATUS_NOT_RECEIVED:
-                    {
                         remoteArrivalTime = RTCP_TWCC_PACKET_LOST_TIME;
-                    }
-                    break;
+                        break;
 
                     case RTCP_TWCC_PACKET_STATUS_SMALL_DELTA:
-                    {
+
                         if( currentReceiveDeltaIndex < pRtcpPacket->payloadLength )
                         {
                             recvDelta = ( uint16_t ) ( pRtcpPacket->pPayload[ currentReceiveDeltaIndex ] );
@@ -451,11 +445,11 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                         {
                             result = RTCP_RESULT_MALFORMED_PACKET;
                         }
-                    }
-                    break;
+
+                        break;
 
                     case RTCP_TWCC_PACKET_STATUS_LARGE_DELTA:
-                    {
+
                         if( ( currentReceiveDeltaIndex + 1 ) < pRtcpPacket->payloadLength )
                         {
                             recvDelta = RTCP_READ_UINT16( &( pRtcpPacket->pPayload[ currentReceiveDeltaIndex ] ) );
@@ -468,8 +462,8 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                         {
                             result = RTCP_RESULT_MALFORMED_PACKET;
                         }
-                    }
-                    break;
+
+                        break;
                 }
 
                 if( pTwccPacket->pArrivalInfoList != NULL )
@@ -508,13 +502,11 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                 switch( statusSymbol )
                 {
                     case RTCP_TWCC_PACKET_STATUS_NOT_RECEIVED:
-                    {
                         remoteArrivalTime = RTCP_TWCC_PACKET_LOST_TIME;
-                    }
-                    break;
+                        break;
 
                     case RTCP_TWCC_PACKET_STATUS_SMALL_DELTA:
-                    {
+
                         if( currentReceiveDeltaIndex < pRtcpPacket->payloadLength )
                         {
                             recvDelta = ( uint16_t ) ( pRtcpPacket->pPayload[ currentReceiveDeltaIndex ] );
@@ -527,11 +519,11 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                         {
                             result = RTCP_RESULT_MALFORMED_PACKET;
                         }
-                    }
-                    break;
+
+                        break;
 
                     case RTCP_TWCC_PACKET_STATUS_LARGE_DELTA:
-                    {
+
                         if( ( currentReceiveDeltaIndex + 1 ) < pRtcpPacket->payloadLength )
                         {
                             recvDelta = RTCP_READ_UINT16( &( pRtcpPacket->pPayload[ currentReceiveDeltaIndex ] ) );
@@ -544,8 +536,8 @@ static RtcpResult_t ParseTwccPacketChunks( RtcpContext_t * pCtx,
                         {
                             result = RTCP_RESULT_MALFORMED_PACKET;
                         }
-                    }
-                    break;
+
+                        break;
                 }
 
                 if( pTwccPacket->pArrivalInfoList != NULL )
@@ -658,7 +650,7 @@ RtcpResult_t Rtcp_SerializeSenderReport( RtcpContext_t * pCtx,
         for( i = 0; i < pSenderReport->numReceptionReports; i++ )
         {
             WriteReceptionReport( pCtx,
-                                  &( pSenderReport->pReceptionReports[ i ]  ),
+                                  &( pSenderReport->pReceptionReports[ i ] ),
                                   pBuffer,
                                   currentIndex );
             currentIndex += RTCP_RECEPTION_REPORT_LENGTH;
@@ -726,7 +718,7 @@ RtcpResult_t Rtcp_SerializeReceiverReport( RtcpContext_t * pCtx,
         for( i = 0; i < pReceiverReport->numReceptionReports; i++ )
         {
             WriteReceptionReport( pCtx,
-                                  &( pReceiverReport->pReceptionReports[ i ]  ),
+                                  &( pReceiverReport->pReceptionReports[ i ] ),
                                   pBuffer,
                                   currentIndex );
             currentIndex += RTCP_RECEPTION_REPORT_LENGTH;
@@ -750,6 +742,7 @@ RtcpResult_t Rtcp_DeserializePacket( RtcpContext_t * pCtx,
     RtcpResult_t result = RTCP_RESULT_OK;
     uint32_t firstWord;
     size_t packetLengthInWords;
+    RtcpPacketType_t rtcpPacketType;
     uint8_t packetType, fmt;
 
     if( ( pCtx == NULL ) ||
@@ -789,17 +782,24 @@ RtcpResult_t Rtcp_DeserializePacket( RtcpContext_t * pCtx,
 
     if( result == RTCP_RESULT_OK )
     {
-        pRtcpPacket->header.padding = ( firstWord & RTCP_HEADER_PADDING_BITMASK ) >>
-                                      RTCP_HEADER_PADDING_LOCATION;
-
-         /* RC field is FMT in some Application Feedback and Transport Feedback
-          * messages. */
+        /* RC field is FMT in some Application Feedback and Transport Feedback
+         * messages. */
         fmt = ( firstWord & RTCP_HEADER_RC_BITMASK ) >>
               RTCP_HEADER_RC_LOCATION;
         packetType = ( firstWord & RTCP_HEADER_PACKET_TYPE_BITMASK ) >>
                      RTCP_HEADER_PACKET_TYPE_LOCATION;
 
-        pRtcpPacket->header.packetType = GetRtcpPacketType( packetType, fmt );
+        rtcpPacketType = GetRtcpPacketType( packetType, fmt );
+
+        if( rtcpPacketType == RTCP_PACKET_UNKNOWN )
+        {
+            result = RTCP_RESULT_MALFORMED_PACKET;
+        }
+
+        pRtcpPacket->header.padding = ( firstWord & RTCP_HEADER_PADDING_BITMASK ) >>
+                                      RTCP_HEADER_PADDING_LOCATION;
+
+        pRtcpPacket->header.packetType = rtcpPacketType;
         pRtcpPacket->header.receptionReportCount = fmt;
 
         pRtcpPacket->pPayload = &( pSerializedPacket[ RTCP_HEADER_LENGTH ] );
@@ -897,6 +897,7 @@ RtcpResult_t Rtcp_ParseSliPacket( RtcpContext_t * pCtx,
                 currentIndex += 4;
                 numSliInfos += 1;
             }
+
             pSliPacket->numSliInfos = numSliInfos;
         }
     }
@@ -926,7 +927,7 @@ RtcpResult_t Rtcp_ParseRembPacket( RtcpContext_t * pCtx,
     }
 
     if( ( result == RTCP_RESULT_OK ) &&
-         ( pRtcpPacket->payloadLength < RTCP_REMB_PACKET_MIN_PAYLOAD_LENGTH ) )
+        ( pRtcpPacket->payloadLength < RTCP_REMB_PACKET_MIN_PAYLOAD_LENGTH ) )
     {
         result = RTCP_RESULT_INPUT_REMB_PACKET_INVALID;
     }
@@ -979,6 +980,7 @@ RtcpResult_t Rtcp_ParseRembPacket( RtcpContext_t * pCtx,
             pRembPacket->pSsrcList[ i ] = RTCP_READ_UINT32( &( pRtcpPacket->pPayload[ currentIndex ] ) );
             currentIndex += 4;
         }
+
         pRembPacket->ssrcListLength = numSsrc;
     }
 
@@ -1044,6 +1046,7 @@ RtcpResult_t Rtcp_ParseSenderReport( RtcpContext_t * pCtx,
                                  &( pSenderReport->pReceptionReports[ i ] ) );
             currentIndex += RTCP_RECEPTION_REPORT_LENGTH;
         }
+
         pSenderReport->numReceptionReports = pRtcpPacket->header.receptionReportCount;
     }
 
@@ -1102,6 +1105,7 @@ RtcpResult_t Rtcp_ParseReceiverReport( RtcpContext_t * pCtx,
                                  &( pReceiverReport->pReceptionReports[ i ] ) );
             currentIndex += RTCP_RECEPTION_REPORT_LENGTH;
         }
+
         pReceiverReport->numReceptionReports = pRtcpPacket->header.receptionReportCount;
     }
 
@@ -1123,7 +1127,7 @@ RtcpResult_t Rtcp_ParseNackPacket( RtcpContext_t * pCtx,
         ( pNackPacket == NULL ) ||
         ( pRtcpPacket->pPayload == NULL ) ||
         ( pRtcpPacket->payloadLength < RTCP_NACK_PACKET_MIN_PAYLOAD_LENGTH ) ||
-        ( ( pRtcpPacket->payloadLength % 4 ) != 0  ) ||
+        ( ( pRtcpPacket->payloadLength % 4 ) != 0 ) ||
         ( pRtcpPacket->header.packetType != RTCP_PACKET_TRANSPORT_FEEDBACK_NACK ) )
     {
         result = RTCP_RESULT_BAD_PARAM;
@@ -1158,6 +1162,7 @@ RtcpResult_t Rtcp_ParseNackPacket( RtcpContext_t * pCtx,
                     break;
                 }
             }
+
             seqNumCount += 1;
 
             /* Iterate over 16 bits of bitmask. */
@@ -1177,10 +1182,12 @@ RtcpResult_t Rtcp_ParseNackPacket( RtcpContext_t * pCtx,
                             break;
                         }
                     }
+
                     seqNumCount += 1;
                 }
             }
         }
+
         pNackPacket->seqNumListLength = seqNumCount;
     }
 

--- a/source/rtcp_twcc_manager.c
+++ b/source/rtcp_twcc_manager.c
@@ -37,7 +37,8 @@ static void DeleteOlderPacketInfos( RtcpTwccManager_t * pTwccManager,
     count = pTwccManager->count;
     readIndex = pTwccManager->readIndex;
 
-    for( i = 0; i < count; i++ )
+    /* If  i == count - 1 then the newly added packet is the one to be deleted, which is never the case. Hence i < count - 1  */
+    for( i = 0; i < count - 1 ; i++ )
     {
         pTwccPacketInfo = &( pTwccManager->pTwccPacketInfoArray[ WRAP( readIndex + i,
                                                                        pTwccManager->twccPacketInfoArrayLength ) ] );

--- a/source/rtcp_twcc_manager.c
+++ b/source/rtcp_twcc_manager.c
@@ -37,7 +37,8 @@ static void DeleteOlderPacketInfos( RtcpTwccManager_t * pTwccManager,
     count = pTwccManager->count;
     readIndex = pTwccManager->readIndex;
 
-    /* If  i == count - 1 then the newly added packet is the one to be deleted, which is never the case. Hence i < count - 1  */
+    /* If i == count - 1 then the newly added packet is the one to be deleted,
+     * which is never the case. Hence i < count - 1. */
     for( i = 0; i < count - 1 ; i++ )
     {
         pTwccPacketInfo = &( pTwccManager->pTwccPacketInfoArray[ WRAP( readIndex + i,

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -93,6 +93,7 @@ add_custom_target( coverage
     COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
     -P ${MODULE_ROOT_DIR}/test/unit-test/cmock/coverage.cmake
     DEPENDS cmock unity
+    rtcp_api
     twcc_manager
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -18,6 +18,7 @@ execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
                          --rc lcov_branch_coverage=1
                          --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
                          --include "*source*"
+                         --exclude "*source/rtcp_endianness.c*"
         )
 file(GLOB files "${CMAKE_BINARY_DIR}/bin/tests/*")
 
@@ -52,6 +53,7 @@ execute_process(
                          --directory ${CMAKE_BINARY_DIR}
                          --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
                          --include "*source*"
+                         --exclude "*source/rtcp_endianness.c*"
         )
 
 # Combile baseline results (zeros) with the one after running the tests.
@@ -63,6 +65,7 @@ execute_process(
                          --output-file ${CMAKE_BINARY_DIR}/coverage.info
                          --rc lcov_branch_coverage=1
                          --include "*source*"
+                         --exclude "*source/rtcp_endianness.c*"
         )
 execute_process(
             COMMAND genhtml --rc lcov_branch_coverage=1

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -19,7 +19,12 @@ execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
                          --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
                          --include "*source*"
                          --exclude "*source/rtcp_endianness.c*"
-        )
+        )               # The functions in rtcp_endianness.c file handle endianness-specific operations for both
+                        # little-endian and big-endian systems. Due to the nature of these operations,
+                        # it is not possible to achieve 100% code coverage as the execution path taken
+                        # depends on the endianness of the target system. Therefore, some branches may
+                        # remain uncovered during testing on a specific endianness.
+                        
 file(GLOB files "${CMAKE_BINARY_DIR}/bin/tests/*")
 
 set(REPORT_FILE ${CMAKE_BINARY_DIR}/utest_report.txt)

--- a/test/unit-test/rtcp_api/rtcp_api_utest.c
+++ b/test/unit-test/rtcp_api/rtcp_api_utest.c
@@ -188,26 +188,26 @@ void test_rtcpSerializeSenderReport( void )
     RtcpReceptionReport_t receptionReports[ 2 ];
     uint8_t serializedReport[] =
     {
-        0x82, 0xC8, 0x00, 0x12, /* Header: V=2, P=0, RC=2, PT=SR=200, Length=18 words. */
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x82, 0xC8, 0x00, 0x12,                         /* Header: V=2, P=0, RC=2, PT=SR=200, Length=18 words. */
+        0x12, 0x34, 0x56, 0x78,                         /* Sender SSRC. */
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, /* Sender Info (ntpTime). */
-        0x99, 0xAA, 0xBB, 0xCC, /* Sender Info (rtpTime). */
-        0x44, 0x33, 0x22, 0x11, /* Sender Info (packetCount). */
-        0xAA, 0xBB, 0xCC, 0xDD, /* Sender Info (octetCount). */
+        0x99, 0xAA, 0xBB, 0xCC,                         /* Sender Info (rtpTime). */
+        0x44, 0x33, 0x22, 0x11,                         /* Sender Info (packetCount). */
+        0xAA, 0xBB, 0xCC, 0xDD,                         /* Sender Info (octetCount). */
         /* Reception Report 1. */
-        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
-        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
-        0xDE, 0xAD, 0xBE, 0xEF, /* Delay since last SR = 0xDEADBEEF. */
+        0x00, 0x00, 0x00, 0x01,                         /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
+        0xDE, 0xAD, 0xBE, 0xEF,                         /* Delay since last SR = 0xDEADBEEF. */
         /* Reception Report 2. */
-        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
-        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
-        0xDE, 0xAD, 0xBE, 0xEF, /* Delay since last SR = 0xDEADBEEF. */
+        0x00, 0x00, 0x00, 0x02,                         /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
+        0xDE, 0xAD, 0xBE, 0xEF,                         /* Delay since last SR = 0xDEADBEEF. */
     };
     size_t serializedReportLength = sizeof( serializedReport );
 
@@ -541,6 +541,7 @@ void test_rtcpDeSerializePacket_MalformedPacked( void )
     RtcpContext_t context;
     RtcpPacket_t rtcpPacket = { 0 };
     RtcpResult_t result;
+
     /* Both the reception report have one word missing (Delay since last SR). As
      * a result, the actual length of the packet is less than the length of
      * the packet encoded in the header. */
@@ -580,16 +581,593 @@ void test_rtcpDeSerializePacket_MalformedPacked( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate RTCP DeSerialize Packet functionality for an unkown type packet.
+ */
+void test_rtcpDeSerializePacket_UNKOWN( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x9F, 0xFE, 0x00, 0x0D, /* Header: V=2, P=0, RC=31, PT=RR=254, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 31,
+                       rtcpPacket.header.receptionReportCount );
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Validate RTCP DeSerialize Packet functionality.
  */
-void test_rtcpDeSerializePacket( void )
+void test_rtcpDeSerializePacket_FIR( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x80, 0xC0, 0x00, 0x0D, /* Header: V=2, P=0, FMT=0, PT=RR=192, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.receptionReportCount );
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_FIR_Invalid( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x82, 0xC0, 0x00, 0x0D, /* Header: V=2, P=0, FMT=2, PT=RR=192, Length = 0xD words. */
+        /* FMT For FIR Packet should be 0 , Hence Invalid */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 2,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_SenderReport( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x82, 0xC8, 0x00, 0x0D, /* Header: V=2, P=0, FMT=2, PT=RR=200, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 2,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_TransportSpecificFeedback( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x81, 0xCD, 0x00, 0x0D, /* Header: V=2, P=0, FMT=1, PT=RR=205, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 1,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_TransportSpecificFeedback_TWCC( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x8F, 0xCD, 0x00, 0x0D,  /* Header: V=2, P=0, FMT=15, PT=RR=205, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 15,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_TransportSpecificFeedback_unknown( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x9F, 0xCD, 0x00, 0x0D, /* Header: V=2, P=0, FMT=31, PT=RR=205, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 31,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_PayloadSpecificFeedback_PLI( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x82, 0xCE, 0x00, 0x0D, /* Header: V=2, P=0, FMT=2, PT=RR=206, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 2,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_PayloadSpecificFeedback_SLI( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x81, 0xCE, 0x00, 0x07, /* Header: V=2, P=0, FMT=1, PT=RR=206, Length = 0x7 words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 1,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_PayloadSpecificFeedback_REMB( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x8F, 0xCE, 0x00, 0x0D, /* Header: V=2, P=0, FMT=15, PT=RR=206, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 15,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_PayloadSpecificFeedback_unknown( void )
+{
+    RtcpContext_t context;
+    uint8_t serializedPacket[] =
+    {
+        0x9F, 0xCE, 0x00, 0x0D, /* Header: V=2, P=0, FMT=31, PT=RR=206, Length = 0xD words. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* Reception Report 1. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        /* Reception Report 2. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+    };
+    size_t serializedPacketLength = sizeof( serializedPacket );
+    RtcpPacket_t rtcpPacket = { 0 };
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    result = Rtcp_DeserializePacket( &( context ),
+                                     &( serializedPacket[ 0 ] ),
+                                     serializedPacketLength,
+                                     &( rtcpPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( 31,
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
+                           rtcpPacket.pPayload );
+    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
+                       rtcpPacket.payloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP DeSerialize Packet functionality.
+ */
+void test_rtcpDeSerializePacket_ReceiverReport( void )
 {
     RtcpContext_t context;
     RtcpPacket_t rtcpPacket = { 0 };
     RtcpResult_t result;
     uint8_t serializedPacket[] =
     {
-        0x82, 0xC9, 0x00, 0x0D, /* Header: V=2, P=0, RC=2, PT=RR=201, Length = 0xD words. */
+        0x82, 0xC9, 0x00, 0x0D, /* Header: V=2, P=0, FMT=2, PT=RR=201, Length = 0xD words. */
         0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
@@ -623,7 +1201,7 @@ void test_rtcpDeSerializePacket( void )
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 2,
-                       rtcpPacket.header.receptionReportCount );
+                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
     TEST_ASSERT_EQUAL( RTCP_PACKET_RECEIVER_REPORT,
                        rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
@@ -918,6 +1496,59 @@ void test_rtcpParseSliPacket_BadParams( void )
 /**
  * @brief Validate RTCP Parse Sli Packet functionality.
  */
+void test_rtcpParseSliPacket_NullInfo( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpSliPacket_t rtcpSliPacket;
+    RtcpResult_t result;
+    uint8_t sliPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Media Source SSRC */
+        /* SLI Info 1: First = 7191, Number = 6242, Picture ID = 31. */
+        0xE0, 0xBE, 0x18, 0x9F,
+    };
+
+    /*
+     *  Even though in the payload an SLI Info is going, since the rtcpSliPacket has pSliInfos as NULL, no such SLI Info's are retrieved.
+     */
+    size_t sliPacketPayloadLength = sizeof( sliPacketPayload );
+    
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    rtcpPacket.header.padding = 0;
+    rtcpPacket.header.receptionReportCount = 0;
+    rtcpPacket.header.packetType = RTCP_PACKET_PAYLOAD_FEEDBACK_SLI;
+    rtcpPacket.pPayload = &( sliPacketPayload[ 0 ] );
+    rtcpPacket.payloadLength = sliPacketPayloadLength;
+
+    rtcpSliPacket.pSliInfos = NULL;
+    rtcpSliPacket.numSliInfos = 0;
+
+    result = Rtcp_ParseSliPacket( &( context ),
+                                  &( rtcpPacket ),
+                                  &( rtcpSliPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0x12345678,
+                       rtcpSliPacket.senderSsrc );
+    TEST_ASSERT_EQUAL( 0x87654321,
+                       rtcpSliPacket.mediaSourceSsrc );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpSliPacket.numSliInfos );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Sli Packet functionality.
+ */
 void test_rtcpParseSliPacket( void )
 {
     RtcpContext_t context;
@@ -934,6 +1565,7 @@ void test_rtcpParseSliPacket( void )
         /* SLI Info 2: First = 5287, Number = 6541, Picture ID = 28. */
         0xA5, 0x3E, 0x63, 0x5C,
     };
+
     /*
      * SLI Info 1:
      *
@@ -1310,25 +1942,25 @@ void test_rtcpParseSenderReport_OutOfMemory( void )
     RtcpSenderReport_t rtcpSenderReport;
     uint8_t senderReportPayload[] =
     {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x12, 0x34, 0x56, 0x78,                         /* Sender SSRC. */
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, /* Sender Info (ntpTime). */
-        0x99, 0xAA, 0xBB, 0xCC, /* Sender Info (rtpTime). */
-        0x00, 0x00, 0x03, 0xE8, /* Sender Info (packetCount). */
-        0x00, 0x01, 0x86, 0xA0, /* Sender Info (octetCount). */
+        0x99, 0xAA, 0xBB, 0xCC,                         /* Sender Info (rtpTime). */
+        0x00, 0x00, 0x03, 0xE8,                         /* Sender Info (packetCount). */
+        0x00, 0x01, 0x86, 0xA0,                         /* Sender Info (octetCount). */
         /* Reception Report 1. */
-        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
-        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x01,                         /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
         /* Reception Report 2. */
-        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
-        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x02,                         /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
     };
     size_t senderReportPayloadLength = sizeof( senderReportPayload );
 
@@ -1367,18 +1999,18 @@ void test_rtcpParseSenderReport_MalformedPacket( void )
     RtcpSenderReport_t rtcpSenderReport;
     uint8_t senderReportPayload[] =
     {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x12, 0x34, 0x56, 0x78,                         /* Sender SSRC. */
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, /* Sender Info (ntpTime). */
-        0x99, 0xAA, 0xBB, 0xCC, /* Sender Info (rtpTime). */
-        0x00, 0x00, 0x03, 0xE8, /* Sender Info (packetCount). */
-        0x00, 0x01, 0x86, 0xA0, /* Sender Info (octetCount). */
+        0x99, 0xAA, 0xBB, 0xCC,                         /* Sender Info (rtpTime). */
+        0x00, 0x00, 0x03, 0xE8,                         /* Sender Info (packetCount). */
+        0x00, 0x01, 0x86, 0xA0,                         /* Sender Info (octetCount). */
         /* Reception Report 1. */
-        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
-        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x01,                         /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
     };
     size_t senderReportPayloadLength = sizeof( senderReportPayload );
 
@@ -1418,25 +2050,25 @@ void test_rtcpParseSenderReport( void )
     RtcpSenderReport_t rtcpSenderReport;
     uint8_t senderReportPayload[] =
     {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x12, 0x34, 0x56, 0x78,                         /* Sender SSRC. */
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, /* Sender Info (ntpTime). */
-        0x99, 0xAA, 0xBB, 0xCC, /* Sender Info (rtpTime). */
-        0x00, 0x00, 0x03, 0xE8, /* Sender Info (packetCount). */
-        0x00, 0x01, 0x86, 0xA0, /* Sender Info (octetCount). */
+        0x99, 0xAA, 0xBB, 0xCC,                         /* Sender Info (rtpTime). */
+        0x00, 0x00, 0x03, 0xE8,                         /* Sender Info (packetCount). */
+        0x00, 0x01, 0x86, 0xA0,                         /* Sender Info (octetCount). */
         /* Reception Report 1. */
-        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
-        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x01,                         /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
         /* Reception Report 2. */
-        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
-        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x02,                         /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
     };
     size_t senderReportPayloadLength = sizeof( senderReportPayload );
 
@@ -1475,6 +2107,7 @@ void test_rtcpParseSenderReport( void )
                        rtcpSenderReport.pReceptionReports[ 0 ].sourceSsrc );
     TEST_ASSERT_EQUAL( 0x00000002,
                        rtcpSenderReport.pReceptionReports[ 1 ].sourceSsrc );
+
     for( i = 0; i < 2; i++ )
     {
         TEST_ASSERT_EQUAL( 0x11,
@@ -1718,6 +2351,7 @@ void test_rtcpParseReceiverReport( void )
                        rtcpReceiverReport.pReceptionReports[ 0 ].sourceSsrc );
     TEST_ASSERT_EQUAL( 0x00000002,
                        rtcpReceiverReport.pReceptionReports[ 1 ].sourceSsrc );
+
     for( i = 0; i < 2; i++ )
     {
         TEST_ASSERT_EQUAL( 0x11,
@@ -1789,6 +2423,17 @@ void test_rtcpParseNackPacket_BadParams( void )
     TEST_ASSERT_EQUAL( RTCP_RESULT_BAD_PARAM,
                        result );
 
+    /* Payload length not a multiple of 4. */
+    rtcpPacket.payloadLength = 14;
+    rtcpPacket.pPayload = &( nackPacketPayload[ 0 ] );
+
+    result = Rtcp_ParseNackPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpNackPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_BAD_PARAM,
+                       result );
+
     rtcpPacket.payloadLength = 40;
     rtcpPacket.pPayload = &( nackPacketPayload[ 0 ] );
     /* Packet type not RTCP_PACKET_TRANSPORT_FEEDBACK_NACK. */
@@ -1821,6 +2466,7 @@ void test_rtcpParseNackPacket( void )
         /* NACK: PID = 0x063B, BLP = 0x0A09. */
         0x06, 0x3B, 0x0A, 0x09
     };
+
     /*
      * NACK details:
      *
@@ -1861,7 +2507,7 @@ void test_rtcpParseNackPacket( void )
     TEST_ASSERT_EQUAL( 0x9ABCDEF0,
                        rtcpNackPacket.mediaSourceSsrc );
     TEST_ASSERT_EQUAL( 5,
-                       rtcpNackPacket.seqNumListLength);
+                       rtcpNackPacket.seqNumListLength );
     TEST_ASSERT_EQUAL( 1595,
                        rtcpNackPacket.pSeqNumList[ 0 ] );
     TEST_ASSERT_EQUAL( 1596,
@@ -1918,7 +2564,7 @@ void test_rtcpParseNackPacket_NullSequenceList( void )
     TEST_ASSERT_EQUAL( 0x9ABCDEF0,
                        rtcpNackPacket.mediaSourceSsrc );
     TEST_ASSERT_EQUAL( 5,
-                       rtcpNackPacket.seqNumListLength);
+                       rtcpNackPacket.seqNumListLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -2040,6 +2686,733 @@ void test_rtcpParseTwccPacket_BadParams( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_BAD_PARAM,
                        result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Run Length with Malformed Small Delta.
+ */
+void test_rtcpParseTwccPacket_RunLengthChunk_SMALLDELTA_MALFORMED( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x02,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1) */
+        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk */
+        0x02
+    };
+
+    /*
+     * Packet Chunk :
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |0|0 1|0 0 0 0 0 0 0 0 0 0 0 1 0|
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     * Since there are 2 small Delta's packets received, but in the payload there is not enough "recv delta" for both the received packets.
+     *
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = NULL;
+    rtcpTwccPacket.arrivalInfoListLength = 0;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Run Length with Malformed Big Delta.
+ */
+void test_rtcpParseTwccPacket_RunLengthChunk_BIGDELTA_MALFORMED( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x02,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1) */
+        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk */
+        0x80,                   /* Large Receive Delta (0x80 = -128 * 64ms = -2097088ms) */
+    };
+
+    /*
+     * Packet Chunk :
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |0|1 0|0 0 0 0 0 0 0 0 0 0 0 0 1|
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     * Since there is 1 Big Delta packet received, but in the payload there is not enough "recv delta" for the received packets ( Since 1 Big-Delta packet needs a 16 bit "recv delta" ).
+     *
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = NULL;
+    rtcpTwccPacket.arrivalInfoListLength = 0;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Run Length with Out of Memory.
+ */
+void test_rtcpParseTwccPacket_RunLengthChunk_OutOfMemory( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    PacketArrivalInfo_t packetArrivalInfo[ 7 ];
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x04,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1) */
+        0x00, 0xDD,             /* Packet Status (Not Received), Run Length Chunk */
+        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk */
+        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk */
+        /* recv delta */
+        0x02, 0x01,             /* First Receive Delta (2 * 64ms = 128ms) */ /* Second Receive Delta (1 * 64ms = 64ms) */
+        0x80, 0x01              /* Large Receive Delta (0x8001 = -32767 * 64ms = -2097088ms) */
+    };
+
+    /*
+     * rtcpTwccPacket Info List Length is 7, but the number of arrival info's are far greater than 7 thus out of memory.
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = &( packetArrivalInfo[ 0 ] );
+    rtcpTwccPacket.arrivalInfoListLength = 7;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Run Length with non-empty ArrivalInfoList.
+ */
+void test_rtcpParseTwccPacket_RunLengthChunk_ArrivalInfoList( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    PacketArrivalInfo_t packetArrivalInfo[ 224 ];
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0xE0,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time (0), Feedback Packet Count (2) */
+        0x00, 0xDD,             /* Packet Status (Not Received), Run Length Chunk */
+        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk */
+        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk */
+        /* recv delta */
+        0x02, 0x01,             /* First Receive Delta (2 * 64ms = 128ms) */ /* Second Receive Delta (1 * 64ms = 64ms) */
+        0x80, 0x01              /* Large Receive Delta (0x8001 = -32767 * 64ms = -2097088ms) */
+    };
+
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = &( packetArrivalInfo[ 0 ] );
+    rtcpTwccPacket.arrivalInfoListLength = 224;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0x12345678,
+                       rtcpTwccPacket.senderSsrc );
+    TEST_ASSERT_EQUAL( 0x9ABCDEF0,
+                       rtcpTwccPacket.mediaSourceSsrc );
+    TEST_ASSERT_EQUAL( 0x0001,
+                       rtcpTwccPacket.baseSeqNum );
+    TEST_ASSERT_EQUAL( 224,
+                       rtcpTwccPacket.packetStatusCount );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpTwccPacket.referenceTime );
+    TEST_ASSERT_EQUAL( 2,
+                       rtcpTwccPacket.feedbackPacketCount );
+    TEST_ASSERT_EQUAL( 224,
+                       rtcpTwccPacket.arrivalInfoListLength );
+    TEST_ASSERT_EQUAL( 0x0001,
+                       rtcpTwccPacket.pArrivalInfoList[ 0 ].seqNum );
+    TEST_ASSERT_EQUAL( RTCP_TWCC_PACKET_LOST_TIME,
+                       rtcpTwccPacket.pArrivalInfoList[ 0 ].remoteArrivalTime );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Run Length with EMPTY ArrivalInfoList.
+ */
+void test_rtcpParseTwccPacket_RunLengthChunk( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0xE0,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x03, /* Reference Time ( 0 ), Feedback Packet Count ( 3 ) */
+        0x00, 0xDD,             /* Packet Status ( Not Received ), Run Length Chunk */
+        0x20, 0x02,             /* Packet Status ( small Delta ), Run Length Chunk */
+        0x40, 0x01,             /* Packet Status ( Big Delta ), Run Length Chunk */
+        /* recv delta */
+        0x02, 0x01,             /* First Receive Delta ( 2 * 64ms = 128ms ) */ /* Second Receive Delta ( 1 * 64ms = 64ms ) */
+        0x80, 0x01,             /* Large Receive Delta ( 0x8001 = -32767 * 64ms = -2097088ms ) */
+    };
+
+    /*
+     *  Packet Chunk ( Not Received - 0x00DD ) :
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |0|0 0|0 0 0 0 0 1 1 0 1 1 1 0 1|                  Total 221 Packet status as not received
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     *  Packet Chunk ( Small Detla - 0x2002 ) :
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |0|0 1|0 0 0 0 0 0 0 0 0 0 0 1 0|                  Total 2 Packet status as Small Delta
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     *  Packet Chunk ( Big Detla - 0x4001 ) :
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |0|1 0|0 0 0 0 0 0 0 0 0 0 0 0 1|                  Total 1 Packet status as Big Delta
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     *  Hence total of 224 Status Info received.
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = NULL;
+    rtcpTwccPacket.arrivalInfoListLength = 0;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0x12345678,
+                       rtcpTwccPacket.senderSsrc );
+    TEST_ASSERT_EQUAL( 0x9ABCDEF0,
+                       rtcpTwccPacket.mediaSourceSsrc );
+    TEST_ASSERT_EQUAL( 0x0001,
+                       rtcpTwccPacket.baseSeqNum );
+    TEST_ASSERT_EQUAL( 224,
+                       rtcpTwccPacket.packetStatusCount );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Run Length with Reserved Packets.
+ */
+void test_rtcpParseTwccPacket_RunLengthChunk_ReservedPackets( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x01,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1) */
+        0x60, 0x01,             /* Packet Status (Reserved), Run Length Chunk */
+    };
+
+    /*
+     * Packet Chunk :
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |0|1 1|0 0 0 0 0 0 0 0 0 0 0 0 1|
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     * Since there is 1 reserved packet received. Since Status symbol for 0x6001 is 11 [Reserved]
+     *
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = NULL;
+    rtcpTwccPacket.arrivalInfoListLength = 0;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0x12345678,
+                       rtcpTwccPacket.senderSsrc );
+    TEST_ASSERT_EQUAL( 0x9ABCDEF0,
+                       rtcpTwccPacket.mediaSourceSsrc );
+    TEST_ASSERT_EQUAL( 0x0001,
+                       rtcpTwccPacket.baseSeqNum );
+    TEST_ASSERT_EQUAL( 1,
+                       rtcpTwccPacket.packetStatusCount );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Status Vector Chunk with Malformed Small Delta.
+ */
+void test_rtcpParseTwccPacket_StatusVectorChunk_SMALLDELTA_MALFORMED( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x07,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x07, /* Reference Time ( 0 ), Feedback Packet Count ( 7 ) */
+        0xD1, 0x05,             /* Packet Status ( small Delta ), Status Vector Chunk */
+        /* recv delta */
+        0x01,                   /* First Receive Delta ( 1 * 64ms = 64ms ) */
+        0x02,                   /* First Receive Delta ( 2 * 64ms = 128ms ) */
+    };
+
+    /*
+     * Packet Chunk (Small Detla - 0xD105):
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |1|1|0 1|0 0|0 1|0 0|0 0|0 1|0 1|
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     * Since there is 4 Small Delta packet received, but in the payload there is not enough "recv delta" for the received packets.
+     *
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = NULL;
+    rtcpTwccPacket.arrivalInfoListLength = 0;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Status Vector Chunk with Malformed Big Delta.
+ */
+void test_rtcpParseTwccPacket_StatusVectorChunk_BIGDELTA_MALFORMED( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x02,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ) */
+        0xE0, 0x02,             /* Packet Status ( Big Delta ), Status Vector Chunk */
+        0x80,                   /* Large Receive Delta  */
+        /* No Receive Delta for the second BIG DELTA Packet received. */
+    };
+
+    /*
+     * Packet Chunk (Big Detla - 0xE002):
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |1|1|1 0|0 0|0 0|0 0|0 0|0 0|1 0|
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     * Since there is 2 Big Delta packet received, but in the payload there is not enough "recv delta" for the received packets.
+     *
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = NULL;
+    rtcpTwccPacket.arrivalInfoListLength = 0;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Status Vector Chunk with Basic Symbol.
+ */
+void test_rtcpParseTwccPacket_StatusVectorChunk_BasicSymbol( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x07,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ) */
+        0x84, 0x01,             /* Packet Status (2 received ), Status Vector Chunk */
+        /* recv delta */
+        0x01, 0x02              /* Delta's for both the packets received */
+    };
+
+    /*
+     * Packet Chunk ( Basic Symbol - 0x8401 { Basic Symbol implies that second bit is set to 0, so only packet "received" or "not-received" info is transferred.} ):
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |1|0|0 0 0 1 0 0 0 0 0 0 0 0 0 1|
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     *  There is 2 packet received.
+     *
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = NULL;
+    rtcpTwccPacket.arrivalInfoListLength = 0;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0x12345678,
+                       rtcpTwccPacket.senderSsrc );
+    TEST_ASSERT_EQUAL( 0x9ABCDEF0,
+                       rtcpTwccPacket.mediaSourceSsrc );
+    TEST_ASSERT_EQUAL( 0x0001,
+                       rtcpTwccPacket.baseSeqNum );
+    TEST_ASSERT_EQUAL( 7,
+                       rtcpTwccPacket.packetStatusCount );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Status Vector Chunk with Detailed Symbol.
+ */
+void test_rtcpParseTwccPacket_StatusVectorChunk_DetailSymbol( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x07,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ) */
+        0xED, 0x01,             /* Status Vector Chunk */
+        /* recv delta */
+        0x80, 0x01,             /* Large Receive Delta ( 0x8001 = -32767 * 64ms = -2097088ms ) */
+        0x01, 0x02              /* First Receive Delta ( 1 * 64ms = 64ms ) */   /* Second Receive Delta ( 2 * 64ms = 128ms ) */
+    };
+
+    /*
+     * Packet Chunk (0xED01):
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |1|1|1 0|1 1|0 1|0 0|0 0|0 0|0 1|
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     * 1x Big-Delta Packet.
+     * 1x Reserved Packet.
+     * 1x Small-Delta Packet.
+     * 3x Packet Not Received.
+     * 1x Small-Delta Packet.
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = NULL;
+    rtcpTwccPacket.arrivalInfoListLength = 0;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0x12345678,
+                       rtcpTwccPacket.senderSsrc );
+    TEST_ASSERT_EQUAL( 0x9ABCDEF0,
+                       rtcpTwccPacket.mediaSourceSsrc );
+    TEST_ASSERT_EQUAL( 0x0001,
+                       rtcpTwccPacket.baseSeqNum );
+    TEST_ASSERT_EQUAL( 7,
+                       rtcpTwccPacket.packetStatusCount );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpTwccPacket.referenceTime );
+    TEST_ASSERT_EQUAL( 2,
+                       rtcpTwccPacket.feedbackPacketCount );
+    TEST_ASSERT_EQUAL( 7,
+                       rtcpTwccPacket.arrivalInfoListLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Status Vector Chunk with OutofMemory.
+ */
+void test_rtcpParseTwccPacket_StatusVectorChunk_OutofMemory( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    PacketArrivalInfo_t packetArrivalInfo[ 6 ];
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x07,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ) */
+        0xE1, 0x01,             /* Status Vector Chunk */
+        /* recv delta */
+        0x80, 0x01,
+        0x01, 0x02
+    };
+
+    /*
+     * Packet Chunk ( 0xE101 ):
+     *
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |1|1|1 0|0 0|0 1|0 0|0 0|0 0|0 1|
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     *
+     * 1x Big-Delta Packet.
+     * 1x Packet Not Received.
+     * 1x Small-Delta Packet.
+     * 3x Packet Not Received.
+     * 1x Small-Delta Packet.
+     *
+     * Since status of 7 packets is received, but the pArrivalInfoList has size of 6 packets. Hence Out of Memory.
+     */
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = &( packetArrivalInfo[ 0 ] );
+    rtcpTwccPacket.arrivalInfoListLength = 6;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate RTCP Parse Twcc Packet functionality for Status Vector Chunk with Arrival Info List.
+ */
+void test_rtcpParseTwccPacket_StatusVectorChunk_ArrivalInfoList( void )
+{
+    RtcpContext_t context;
+    RtcpPacket_t rtcpPacket;
+    PacketArrivalInfo_t packetArrivalInfo[ 7 ];
+    RtcpTwccPacket_t rtcpTwccPacket;
+    RtcpResult_t result;
+
+    result = Rtcp_Init( &( context ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
+        0x00, 0x01,             /* Base Sequence Number */
+        0x00, 0x07,             /* Packet Status Count */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time (0), Feedback Packet Count (2) */
+        0xE1, 0x01,             /* Status Vector Chunk */
+        /* recv delta */
+        0x80, 0x01,
+        0x01, 0x02
+    };
+
+    rtcpPacket.pPayload = twccPacketPayload;
+    rtcpPacket.payloadLength = sizeof( twccPacketPayload );
+    rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
+
+    rtcpTwccPacket.pArrivalInfoList = &( packetArrivalInfo[ 0 ] );      /* A non NULL arrivalInfo List */
+    rtcpTwccPacket.arrivalInfoListLength = 7;
+
+    result = Rtcp_ParseTwccPacket( &( context ),
+                                   &( rtcpPacket ),
+                                   &( rtcpTwccPacket ) );
+
+    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0x12345678,
+                       rtcpTwccPacket.senderSsrc );
+    TEST_ASSERT_EQUAL( 0x9ABCDEF0,
+                       rtcpTwccPacket.mediaSourceSsrc );
+    TEST_ASSERT_EQUAL( 0x0001,
+                       rtcpTwccPacket.baseSeqNum );
+    TEST_ASSERT_EQUAL( 7,
+                       rtcpTwccPacket.packetStatusCount );
+    TEST_ASSERT_EQUAL( 0,
+                       rtcpTwccPacket.referenceTime );
+    TEST_ASSERT_EQUAL( 2,
+                       rtcpTwccPacket.feedbackPacketCount );
+    TEST_ASSERT_EQUAL( 7,
+                       rtcpTwccPacket.arrivalInfoListLength );
+    TEST_ASSERT_EQUAL( 0x0001,
+                       rtcpTwccPacket.pArrivalInfoList[ 0 ].seqNum );
+    TEST_ASSERT_EQUAL( 293,
+                       rtcpTwccPacket.pArrivalInfoList[ 0 ].remoteArrivalTime );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/rtcp_api/rtcp_api_utest.c
+++ b/test/unit-test/rtcp_api/rtcp_api_utest.c
@@ -188,26 +188,26 @@ void test_rtcpSerializeSenderReport( void )
     RtcpReceptionReport_t receptionReports[ 2 ];
     uint8_t serializedReport[] =
     {
-        0x82, 0xC8, 0x00, 0x12,                         /* Header: V=2, P=0, RC=2, PT=SR=200, Length=18 words. */
-        0x12, 0x34, 0x56, 0x78,                         /* Sender SSRC. */
+        0x82, 0xC8, 0x00, 0x12, /* Header: V=2, P=0, RC=2, PT=SR=200, Length=18 words. */
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, /* Sender Info (ntpTime). */
-        0x99, 0xAA, 0xBB, 0xCC,                         /* Sender Info (rtpTime). */
-        0x44, 0x33, 0x22, 0x11,                         /* Sender Info (packetCount). */
-        0xAA, 0xBB, 0xCC, 0xDD,                         /* Sender Info (octetCount). */
+        0x99, 0xAA, 0xBB, 0xCC, /* Sender Info (rtpTime). */
+        0x44, 0x33, 0x22, 0x11, /* Sender Info (packetCount). */
+        0xAA, 0xBB, 0xCC, 0xDD, /* Sender Info (octetCount). */
         /* Reception Report 1. */
-        0x00, 0x00, 0x00, 0x01,                         /* SSRC of first source. */
-        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
-        0xDE, 0xAD, 0xBE, 0xEF,                         /* Delay since last SR = 0xDEADBEEF. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0xDE, 0xAD, 0xBE, 0xEF, /* Delay since last SR = 0xDEADBEEF. */
         /* Reception Report 2. */
-        0x00, 0x00, 0x00, 0x02,                         /* SSRC of second source. */
-        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
-        0xDE, 0xAD, 0xBE, 0xEF,                         /* Delay since last SR = 0xDEADBEEF. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0xDE, 0xAD, 0xBE, 0xEF, /* Delay since last SR = 0xDEADBEEF. */
     };
     size_t serializedReportLength = sizeof( serializedReport );
 
@@ -548,14 +548,14 @@ void test_rtcpDeSerializePacket_MalformedPacked( void )
     uint8_t serializedPacket[] =
     {
         0x82, 0xC9, 0x00, 0x0D, /* Header: V=2, P=0, RC=2, PT=RR=201, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
-        /* Reception Report 1 */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
+        /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x00, 0x00, 0x00, 0x00, /* Fraction lost and Cumulative packet lost. */
         0x00, 0x00, 0x00, 0x00, /* Extended highest sequence number received. */
         0x00, 0x00, 0x00, 0x00, /* Inter-arrival Jitter. */
         0x00, 0x00, 0x00, 0x00, /* Last SR. */
-        /* Reception Report 2 */
+        /* Reception Report 2. */
         0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
         0x00, 0x00, 0x00, 0x00, /* Fraction lost and Cumulative packet lost. */
         0x00, 0x00, 0x00, 0x00, /* Extended highest sequence number received. */
@@ -583,13 +583,13 @@ void test_rtcpDeSerializePacket_MalformedPacked( void )
 /**
  * @brief Validate RTCP DeSerialize Packet functionality for an unkown type packet.
  */
-void test_rtcpDeSerializePacket_UNKOWN( void )
+void test_rtcpDeSerializePacket_Unknown( void )
 {
     RtcpContext_t context;
     uint8_t serializedPacket[] =
     {
         0x9F, 0xFE, 0x00, 0x0D, /* Header: V=2, P=0, RC=31, PT=RR=254, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -621,16 +621,6 @@ void test_rtcpDeSerializePacket_UNKOWN( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
                        result );
-    TEST_ASSERT_EQUAL( RTCP_PACKET_UNKNOWN,
-                       rtcpPacket.header.packetType );
-    TEST_ASSERT_EQUAL( 0,
-                       rtcpPacket.header.padding );
-    TEST_ASSERT_EQUAL( 31,
-                       rtcpPacket.header.receptionReportCount );
-    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
-                           rtcpPacket.pPayload );
-    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
-                       rtcpPacket.payloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -644,7 +634,7 @@ void test_rtcpDeSerializePacket_FIR( void )
     uint8_t serializedPacket[] =
     {
         0x80, 0xC0, 0x00, 0x0D, /* Header: V=2, P=0, FMT=0, PT=RR=192, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -699,8 +689,8 @@ void test_rtcpDeSerializePacket_FIR_Invalid( void )
     uint8_t serializedPacket[] =
     {
         0x82, 0xC0, 0x00, 0x0D, /* Header: V=2, P=0, FMT=2, PT=RR=192, Length = 0xD words. */
-        /* FMT For FIR Packet should be 0 , Hence Invalid */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        /* FMT For FIR Packet should be 0, hence Invalid. */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -732,16 +722,6 @@ void test_rtcpDeSerializePacket_FIR_Invalid( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
                        result );
-    TEST_ASSERT_EQUAL( RTCP_PACKET_UNKNOWN,
-                       rtcpPacket.header.packetType );
-    TEST_ASSERT_EQUAL( 0,
-                       rtcpPacket.header.padding );
-    TEST_ASSERT_EQUAL( 2,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
-    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
-                           rtcpPacket.pPayload );
-    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
-                       rtcpPacket.payloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -755,7 +735,7 @@ void test_rtcpDeSerializePacket_SenderReport( void )
     uint8_t serializedPacket[] =
     {
         0x82, 0xC8, 0x00, 0x0D, /* Header: V=2, P=0, FMT=2, PT=RR=200, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -792,7 +772,7 @@ void test_rtcpDeSerializePacket_SenderReport( void )
     TEST_ASSERT_EQUAL( RTCP_PACKET_SENDER_REPORT,
                        rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 2,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+                       rtcpPacket.header.receptionReportCount ); /* Feedback message type (FMT). */
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
                            rtcpPacket.pPayload );
     TEST_ASSERT_EQUAL( serializedPacketLength - 4,
@@ -810,7 +790,7 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_Nack( void )
     uint8_t serializedPacket[] =
     {
         0x81, 0xCD, 0x00, 0x0D, /* Header: V=2, P=0, FMT=1, PT=RR=205, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -847,7 +827,7 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_Nack( void )
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 1,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+                       rtcpPacket.header.receptionReportCount ); /* Feedback message type (FMT). */
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
                            rtcpPacket.pPayload );
     TEST_ASSERT_EQUAL( serializedPacketLength - 4,
@@ -865,7 +845,7 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_TWCC( void )
     uint8_t serializedPacket[] =
     {
         0x8F, 0xCD, 0x00, 0x0D, /* Header: V=2, P=0, FMT=15, PT=RR=205, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -902,7 +882,7 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_TWCC( void )
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 15,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+                       rtcpPacket.header.receptionReportCount ); /* Feedback message type (FMT). */
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
                            rtcpPacket.pPayload );
     TEST_ASSERT_EQUAL( serializedPacketLength - 4,
@@ -914,14 +894,15 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_TWCC( void )
 /**
  * @brief Validate RTCP DeSerialize Packet functionality.
  */
-void test_rtcpDeSerializePacket_TransportSpecificFeedback_unknown( void )
+void test_rtcpDeSerializePacket_TransportSpecificFeedback_Unknown( void )
 {
-    /* Thought The Packet Type is of  Transport Specific Feedback, the Feedback Message Type ( FMT ) is Unknown */
+    /* Thought The Packet Type is of Transport Specific Feedback, the Feedback
+     * Message Type ( FMT ) is Unknown. */
     RtcpContext_t context;
     uint8_t serializedPacket[] =
     {
         0x9F, 0xCD, 0x00, 0x0D, /* Header: V=2, P=0, FMT=31, PT=RR=205, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -953,16 +934,6 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_unknown( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
                        result );
-    TEST_ASSERT_EQUAL( RTCP_PACKET_UNKNOWN,
-                       rtcpPacket.header.packetType );
-    TEST_ASSERT_EQUAL( 0,
-                       rtcpPacket.header.padding );
-    TEST_ASSERT_EQUAL( 31,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
-    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
-                           rtcpPacket.pPayload );
-    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
-                       rtcpPacket.payloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -976,7 +947,7 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_SLI( void )
     uint8_t serializedPacket[] =
     {
         0x82, 0xCE, 0x00, 0x0D, /* Header: V=2, P=0, FMT=2, PT=RR=206, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -1013,7 +984,7 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_SLI( void )
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 2,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+                       rtcpPacket.header.receptionReportCount ); /* Feedback message type (FMT). */
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
                            rtcpPacket.pPayload );
     TEST_ASSERT_EQUAL( serializedPacketLength - 4,
@@ -1031,7 +1002,7 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_PLI( void )
     uint8_t serializedPacket[] =
     {
         0x81, 0xCE, 0x00, 0x07, /* Header: V=2, P=0, FMT=1, PT=RR=206, Length = 0x7 words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -1061,7 +1032,7 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_PLI( void )
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 1,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+                       rtcpPacket.header.receptionReportCount ); /* Feedback message type (FMT). */
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
                            rtcpPacket.pPayload );
     TEST_ASSERT_EQUAL( serializedPacketLength - 4,
@@ -1079,7 +1050,7 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_REMB( void )
     uint8_t serializedPacket[] =
     {
         0x8F, 0xCE, 0x00, 0x0D, /* Header: V=2, P=0, FMT=15, PT=RR=206, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -1116,7 +1087,7 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_REMB( void )
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 15,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+                       rtcpPacket.header.receptionReportCount ); /* Feedback message type (FMT). */
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
                            rtcpPacket.pPayload );
     TEST_ASSERT_EQUAL( serializedPacketLength - 4,
@@ -1128,13 +1099,13 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_REMB( void )
 /**
  * @brief Validate RTCP DeSerialize Packet functionality.
  */
-void test_rtcpDeSerializePacket_PayloadSpecificFeedback_unknown( void )
+void test_rtcpDeSerializePacket_PayloadSpecificFeedback_Unknown( void )
 {
     RtcpContext_t context;
     uint8_t serializedPacket[] =
     {
         0x9F, 0xCE, 0x00, 0x0D, /* Header: V=2, P=0, FMT=31, PT=RR=206, Length = 0xD words. */
-        0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
+        0x87, 0x65, 0x43, 0x21, /* Sender SSRC. */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
         0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
@@ -1166,16 +1137,6 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_unknown( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
                        result );
-    TEST_ASSERT_EQUAL( RTCP_PACKET_UNKNOWN,
-                       rtcpPacket.header.packetType );
-    TEST_ASSERT_EQUAL( 0,
-                       rtcpPacket.header.padding );
-    TEST_ASSERT_EQUAL( 31,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
-    TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
-                           rtcpPacket.pPayload );
-    TEST_ASSERT_EQUAL( serializedPacketLength - 4,
-                       rtcpPacket.payloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -1226,7 +1187,7 @@ void test_rtcpDeSerializePacket_ReceiverReport( void )
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 2,
-                       rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
+                       rtcpPacket.header.receptionReportCount ); /* Feedback message type (FMT). */
     TEST_ASSERT_EQUAL( RTCP_PACKET_RECEIVER_REPORT,
                        rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
@@ -1529,17 +1490,15 @@ void test_rtcpParseSliPacket_NullInfo( void )
     RtcpResult_t result;
     uint8_t sliPacketPayload[] =
     {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x87, 0x65, 0x43, 0x21, /* Media Source SSRC */
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x87, 0x65, 0x43, 0x21, /* Media Source SSRC. */
         /* SLI Info 1: First = 7191, Number = 6242, Picture ID = 31. */
         0xE0, 0xBE, 0x18, 0x9F,
     };
 
-    /*
-     *  Even though in the payload an SLI Info is going, since the rtcpSliPacket has pSliInfos as NULL, no such SLI Info's are retrieved.
-     */
+    /* Even though in the payload an SLI Info is present, since the
+     * rtcpSliPacket has pSliInfos as NULL, no such SLI Info's are retrieved. */
     size_t sliPacketPayloadLength = sizeof( sliPacketPayload );
-
 
     result = Rtcp_Init( &( context ) );
 
@@ -1967,25 +1926,25 @@ void test_rtcpParseSenderReport_OutOfMemory( void )
     RtcpSenderReport_t rtcpSenderReport;
     uint8_t senderReportPayload[] =
     {
-        0x12, 0x34, 0x56, 0x78,                         /* Sender SSRC. */
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, /* Sender Info (ntpTime). */
-        0x99, 0xAA, 0xBB, 0xCC,                         /* Sender Info (rtpTime). */
-        0x00, 0x00, 0x03, 0xE8,                         /* Sender Info (packetCount). */
-        0x00, 0x01, 0x86, 0xA0,                         /* Sender Info (octetCount). */
+        0x99, 0xAA, 0xBB, 0xCC, /* Sender Info (rtpTime). */
+        0x00, 0x00, 0x03, 0xE8, /* Sender Info (packetCount). */
+        0x00, 0x01, 0x86, 0xA0, /* Sender Info (octetCount). */
         /* Reception Report 1. */
-        0x00, 0x00, 0x00, 0x01,                         /* SSRC of first source. */
-        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
         /* Reception Report 2. */
-        0x00, 0x00, 0x00, 0x02,                         /* SSRC of second source. */
-        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
     };
     size_t senderReportPayloadLength = sizeof( senderReportPayload );
 
@@ -2024,18 +1983,18 @@ void test_rtcpParseSenderReport_MalformedPacket( void )
     RtcpSenderReport_t rtcpSenderReport;
     uint8_t senderReportPayload[] =
     {
-        0x12, 0x34, 0x56, 0x78,                         /* Sender SSRC. */
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, /* Sender Info (ntpTime). */
-        0x99, 0xAA, 0xBB, 0xCC,                         /* Sender Info (rtpTime). */
-        0x00, 0x00, 0x03, 0xE8,                         /* Sender Info (packetCount). */
-        0x00, 0x01, 0x86, 0xA0,                         /* Sender Info (octetCount). */
+        0x99, 0xAA, 0xBB, 0xCC, /* Sender Info (rtpTime). */
+        0x00, 0x00, 0x03, 0xE8, /* Sender Info (packetCount). */
+        0x00, 0x01, 0x86, 0xA0, /* Sender Info (octetCount). */
         /* Reception Report 1. */
-        0x00, 0x00, 0x00, 0x01,                         /* SSRC of first source. */
-        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
     };
     size_t senderReportPayloadLength = sizeof( senderReportPayload );
 
@@ -2075,25 +2034,25 @@ void test_rtcpParseSenderReport( void )
     RtcpSenderReport_t rtcpSenderReport;
     uint8_t senderReportPayload[] =
     {
-        0x12, 0x34, 0x56, 0x78,                         /* Sender SSRC. */
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, /* Sender Info (ntpTime). */
-        0x99, 0xAA, 0xBB, 0xCC,                         /* Sender Info (rtpTime). */
-        0x00, 0x00, 0x03, 0xE8,                         /* Sender Info (packetCount). */
-        0x00, 0x01, 0x86, 0xA0,                         /* Sender Info (octetCount). */
+        0x99, 0xAA, 0xBB, 0xCC, /* Sender Info (rtpTime). */
+        0x00, 0x00, 0x03, 0xE8, /* Sender Info (packetCount). */
+        0x00, 0x01, 0x86, 0xA0, /* Sender Info (octetCount). */
         /* Reception Report 1. */
-        0x00, 0x00, 0x00, 0x01,                         /* SSRC of first source. */
-        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
         /* Reception Report 2. */
-        0x00, 0x00, 0x00, 0x02,                         /* SSRC of second source. */
-        0x11, 0xA0, 0xA1, 0xA2,                         /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
-        0xD1, 0xD2, 0xD3, 0xD4,                         /* Extended highest sequence number received = 0xD1D2D3D4. */
-        0xB1, 0xB2, 0xB3, 0xB4,                         /* Inter-arrival Jitter = 0xB1B2B3B4. */
-        0xC1, 0xC2, 0xC3, 0xC4,                         /* Last SR = 0xC1C2C3C4. */
-        0x5A, 0x5B, 0x5C, 0x5D,                         /* Delay since last SR = 0x5A5B5C5D. */
+        0x00, 0x00, 0x00, 0x02, /* SSRC of second source. */
+        0x11, 0xA0, 0xA1, 0xA2, /* Fraction lost = 0x11, Cumulative packet lost = 0xA0A1A2. */
+        0xD1, 0xD2, 0xD3, 0xD4, /* Extended highest sequence number received = 0xD1D2D3D4. */
+        0xB1, 0xB2, 0xB3, 0xB4, /* Inter-arrival Jitter = 0xB1B2B3B4. */
+        0xC1, 0xC2, 0xC3, 0xC4, /* Last SR = 0xC1C2C3C4. */
+        0x5A, 0x5B, 0x5C, 0x5D, /* Delay since last SR = 0x5A5B5C5D. */
     };
     size_t senderReportPayloadLength = sizeof( senderReportPayload );
 
@@ -2724,32 +2683,31 @@ void test_rtcpParseTwccPacket_RunLengthChunk_SmallDelta_Malformed( void )
     RtcpPacket_t rtcpPacket;
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x02,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1). */
+        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk. */
+        0x02
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x02,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1) */
-        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk */
-        0x02
-    };
-
     /*
      * Packet Chunk :
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |0|0 1|0 0 0 0 0 0 0 0 0 0 0 1 0|
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |0|0 1|0 0 0 0 0 0 0 0 0 0 0 1 0|
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
-     * Since there are 2 small Delta's packets received, but in the payload there is not enough "recv delta" for both the received packets.
-     *
+     * Since there are 2 small Delta's packets received, but in the payload
+     * there is not enough "recv delta" for both the received packets.
      */
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
@@ -2777,32 +2735,32 @@ void test_rtcpParseTwccPacket_RunLengthChunk_BigDelta_Malformed( void )
     RtcpPacket_t rtcpPacket;
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x02,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1). */
+        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk. */
+        0x80,                   /* Large Receive Delta (0x80 = -128 * 64ms = -2097088ms). */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x02,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1) */
-        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk */
-        0x80,                   /* Large Receive Delta (0x80 = -128 * 64ms = -2097088ms) */
-    };
-
     /*
      * Packet Chunk :
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |0|1 0|0 0 0 0 0 0 0 0 0 0 0 0 1|
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |0|1 0|0 0 0 0 0 0 0 0 0 0 0 0 1|
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
-     * Since there is 1 Big Delta packet received, but in the payload there is not enough "recv delta" for the received packets ( Since 1 Big-Delta packet needs a 16 bit "recv delta" ).
-     *
+     * Since there is 1 Big Delta packet received, but in the payload there is
+     * not enough "recv delta" for the received packets ( Since 1 Big-Delta
+     * packet needs a 16 bit "recv delta" ).
      */
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
@@ -2831,30 +2789,28 @@ void test_rtcpParseTwccPacket_RunLengthChunk_OutOfMemory( void )
     PacketArrivalInfo_t packetArrivalInfo[ 7 ];
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x04,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1). */
+        0x00, 0xDD,             /* Packet Status (Not Received), Run Length Chunk. */
+        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk. */
+        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk. */
+        /* Recv delta. */
+        0x02, 0x01,             /* First Receive Delta (2 * 64ms = 128ms). */ /* Second Receive Delta (1 * 64ms = 64ms). */
+        0x80, 0x01              /* Large Receive Delta (0x8001 = -32767 * 64ms = -2097088ms). */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x04,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1) */
-        0x00, 0xDD,             /* Packet Status (Not Received), Run Length Chunk */
-        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk */
-        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk */
-        /* recv delta */
-        0x02, 0x01,             /* First Receive Delta (2 * 64ms = 128ms) */ /* Second Receive Delta (1 * 64ms = 64ms) */
-        0x80, 0x01              /* Large Receive Delta (0x8001 = -32767 * 64ms = -2097088ms) */
-    };
-
-    /*
-     * rtcpTwccPacket Info List Length is 7, but the number of arrival info's are far greater than 7 thus out of memory.
-     */
+    /* rtcpTwccPacket Info List Length is 7, but the number of arrival info's
+     * are far greater than 7 thus out of memory. */
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
     rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
@@ -2882,26 +2838,25 @@ void test_rtcpParseTwccPacket_RunLengthChunk_ArrivalInfoList( void )
     PacketArrivalInfo_t packetArrivalInfo[ 224 ];
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0xE0,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time (0), Feedback Packet Count (2). */
+        0x00, 0xDD,             /* Packet Status (Not Received), Run Length Chunk. */
+        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk. */
+        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk. */
+        /* Recv delta. */
+        0x02, 0x01,             /* First Receive Delta (2 * 64ms = 128ms). */ /* Second Receive Delta (1 * 64ms = 64ms). */
+        0x80, 0x01              /* Large Receive Delta (0x8001 = -32767 * 64ms = -2097088ms). */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
-
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0xE0,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x02, /* Reference Time (0), Feedback Packet Count (2) */
-        0x00, 0xDD,             /* Packet Status (Not Received), Run Length Chunk */
-        0x20, 0x02,             /* Packet Status (small Delta), Run Length Chunk */
-        0x40, 0x01,             /* Packet Status (Big Delta), Run Length Chunk */
-        /* recv delta */
-        0x02, 0x01,             /* First Receive Delta (2 * 64ms = 128ms) */ /* Second Receive Delta (1 * 64ms = 64ms) */
-        0x80, 0x01              /* Large Receive Delta (0x8001 = -32767 * 64ms = -2097088ms) */
-    };
 
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
@@ -2947,45 +2902,44 @@ void test_rtcpParseTwccPacket_RunLengthChunk( void )
     RtcpPacket_t rtcpPacket;
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0xE0,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x03, /* Reference Time ( 0 ), Feedback Packet Count ( 3 ). */
+        0x00, 0xDD,             /* Packet Status ( Not Received ), Run Length Chunk. */
+        0x20, 0x02,             /* Packet Status ( small Delta ), Run Length Chunk. */
+        0x40, 0x01,             /* Packet Status ( Big Delta ), Run Length Chunk. */
+        /* Recv delta. */
+        0x02, 0x01,             /* First Receive Delta ( 2 * 64ms = 128ms ). */ /* Second Receive Delta ( 1 * 64ms = 64ms ). */
+        0x80, 0x01,             /* Large Receive Delta ( 0x8001 = -32767 * 64ms = -2097088ms ). */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0xE0,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x03, /* Reference Time ( 0 ), Feedback Packet Count ( 3 ) */
-        0x00, 0xDD,             /* Packet Status ( Not Received ), Run Length Chunk */
-        0x20, 0x02,             /* Packet Status ( small Delta ), Run Length Chunk */
-        0x40, 0x01,             /* Packet Status ( Big Delta ), Run Length Chunk */
-        /* recv delta */
-        0x02, 0x01,             /* First Receive Delta ( 2 * 64ms = 128ms ) */ /* Second Receive Delta ( 1 * 64ms = 64ms ) */
-        0x80, 0x01,             /* Large Receive Delta ( 0x8001 = -32767 * 64ms = -2097088ms ) */
-    };
-
     /*
      *  Packet Chunk ( Not Received - 0x00DD ) :
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |0|0 0|0 0 0 0 0 1 1 0 1 1 1 0 1|                  Total 221 Packet status as not received
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |0|0 0|0 0 0 0 0 1 1 0 1 1 1 0 1|    Total 221 Packet status as not received.
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
      *  Packet Chunk ( Small Detla - 0x2002 ) :
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |0|0 1|0 0 0 0 0 0 0 0 0 0 0 1 0|                  Total 2 Packet status as Small Delta
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |0|0 1|0 0 0 0 0 0 0 0 0 0 0 1 0|    Total 2 Packet status as Small Delta.
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
      *  Packet Chunk ( Big Detla - 0x4001 ) :
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |0|1 0|0 0 0 0 0 0 0 0 0 0 0 0 1|                  Total 1 Packet status as Big Delta
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |0|1 0|0 0 0 0 0 0 0 0 0 0 0 0 1|    Total 1 Packet status as Big Delta.
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
      *  Hence total of 224 Status Info received.
      */
@@ -3023,31 +2977,30 @@ void test_rtcpParseTwccPacket_RunLengthChunk_ReservedPackets( void )
     RtcpPacket_t rtcpPacket;
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x01,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1). */
+        0x60, 0x01,             /* Packet Status (Reserved), Run Length Chunk. */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x01,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x01, /* Reference Time (0), Feedback Packet Count (1) */
-        0x60, 0x01,             /* Packet Status (Reserved), Run Length Chunk */
-    };
-
     /*
      * Packet Chunk :
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |0|1 1|0 0 0 0 0 0 0 0 0 0 0 0 1|
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |0|1 1|0 0 0 0 0 0 0 0 0 0 0 0 1|
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
-     * Since there is 1 reserved packet received. Since Status symbol for 0x6001 is 11 [Reserved]
-     *
+     * Since there is 1 reserved packet received. Since Status symbol for 0x6001
+     * is 11 [Reserved].
      */
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
@@ -3083,34 +3036,33 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_SmallDelta_Makformed( void )
     RtcpPacket_t rtcpPacket;
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x07,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x07, /* Reference Time ( 0 ), Feedback Packet Count ( 7 ). */
+        0xD1, 0x05,             /* Packet Status ( small Delta ), Status Vector Chunk. */
+        /* Recv delta. */
+        0x01,                   /* First Receive Delta ( 1 * 64ms = 64ms ). */
+        0x02,                   /* First Receive Delta ( 2 * 64ms = 128ms ). */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x07,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x07, /* Reference Time ( 0 ), Feedback Packet Count ( 7 ) */
-        0xD1, 0x05,             /* Packet Status ( small Delta ), Status Vector Chunk */
-        /* recv delta */
-        0x01,                   /* First Receive Delta ( 1 * 64ms = 64ms ) */
-        0x02,                   /* First Receive Delta ( 2 * 64ms = 128ms ) */
-    };
-
     /*
      * Packet Chunk (Small Detla - 0xD105):
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |1|1|0 1|0 0|0 1|0 0|0 0|0 1|0 1|
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |1|1|0 1|0 0|0 1|0 0|0 0|0 1|0 1|
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
-     * Since there is 4 Small Delta packet received, but in the payload there is not enough "recv delta" for the received packets.
-     *
+     * Since there is 4 Small Delta packet received, but in the payload there is
+     * not enough "recv delta" for the received packets.
      */
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
@@ -3138,33 +3090,32 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_BigDelta_Malformed( void )
     RtcpPacket_t rtcpPacket;
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x02,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ). */
+        0xE0, 0x02,             /* Packet Status ( Big Delta ), Status Vector Chunk. */
+        0x80,                   /* Large Receive Delta. */
+        /* No Receive Delta for the second BIG DELTA Packet received. */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x02,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ) */
-        0xE0, 0x02,             /* Packet Status ( Big Delta ), Status Vector Chunk */
-        0x80,                   /* Large Receive Delta  */
-        /* No Receive Delta for the second BIG DELTA Packet received. */
-    };
-
     /*
      * Packet Chunk (Big Detla - 0xE002):
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |1|1|1 0|0 0|0 0|0 0|0 0|0 0|1 0|
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |1|1|1 0|0 0|0 0|0 0|0 0|0 0|1 0|
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
-     * Since there is 2 Big Delta packet received, but in the payload there is not enough "recv delta" for the received packets.
-     *
+     * Since there is 2 Big Delta packet received, but in the payload there is
+     * not enough "recv delta" for the received packets.
      */
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
@@ -3192,33 +3143,32 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_BasicSymbol( void )
     RtcpPacket_t rtcpPacket;
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x07,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ). */
+        0x84, 0x01,             /* Packet Status (2 received ), Status Vector Chunk. */
+        /* Recv delta. */
+        0x01, 0x02              /* Delta's for both the packets received. */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
-
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x07,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ) */
-        0x84, 0x01,             /* Packet Status (2 received ), Status Vector Chunk */
-        /* recv delta */
-        0x01, 0x02              /* Delta's for both the packets received */
-    };
-
     /*
-     * Packet Chunk ( Basic Symbol - 0x8401 { Basic Symbol implies that second bit is set to 0, so only packet "received" or "not-received" info is transferred.} ):
+     * Packet Chunk ( Basic Symbol - 0x8401 { Basic Symbol implies that second
+     * bit is set to 0, so only packet "received" or "not-received" info is
+     * transferred.} ):
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |1|0|0 0 0 1 0 0 0 0 0 0 0 0 0 1|
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |1|0|0 0 0 1 0 0 0 0 0 0 0 0 0 1|
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
-     *  There is 2 packet received.
-     *
+     * There is 2 packet received.
      */
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
@@ -3254,31 +3204,30 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_DetailSymbol( void )
     RtcpPacket_t rtcpPacket;
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x07,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ). */
+        0xED, 0x01,             /* Status Vector Chunk. */
+        /* Recv delta. */
+        0x80, 0x01,             /* Large Receive Delta ( 0x8001 = -32767 * 64ms = -2097088ms ). */
+        0x01, 0x02              /* First Receive Delta ( 1 * 64ms = 64ms ). */ /* Second Receive Delta ( 2 * 64ms = 128ms ). */
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x07,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ) */
-        0xED, 0x01,             /* Status Vector Chunk */
-        /* recv delta */
-        0x80, 0x01,             /* Large Receive Delta ( 0x8001 = -32767 * 64ms = -2097088ms ) */
-        0x01, 0x02              /* First Receive Delta ( 1 * 64ms = 64ms ) */   /* Second Receive Delta ( 2 * 64ms = 128ms ) */
-    };
-
     /*
      * Packet Chunk (0xED01):
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |1|1|1 0|1 1|0 1|0 0|0 0|0 0|0 1|
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |1|1|1 0|1 1|0 1|0 0|0 0|0 0|0 1|
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
      * 1x Big-Delta Packet.
      * 1x Reserved Packet.
@@ -3327,31 +3276,30 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_OutofMemory( void )
     PacketArrivalInfo_t packetArrivalInfo[ 6 ];
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x07,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ). */
+        0xE1, 0x01,             /* Status Vector Chunk. */
+        /* Recv delta. */
+        0x80, 0x01,
+        0x01, 0x02
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x07,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x02, /* Reference Time ( 0 ), Feedback Packet Count ( 2 ) */
-        0xE1, 0x01,             /* Status Vector Chunk */
-        /* recv delta */
-        0x80, 0x01,
-        0x01, 0x02
-    };
-
     /*
      * Packet Chunk ( 0xE101 ):
      *
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     |1|1|1 0|0 0|0 1|0 0|0 0|0 0|0 1|
-     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |1|1|1 0|0 0|0 1|0 0|0 0|0 0|0 1|
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
      * 1x Big-Delta Packet.
      * 1x Packet Not Received.
@@ -3359,7 +3307,8 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_OutofMemory( void )
      * 3x Packet Not Received.
      * 1x Small-Delta Packet.
      *
-     * Since status of 7 packets is received, but the pArrivalInfoList has size of 6 packets. Hence Out of Memory.
+     * Since status of 7 packets is received, but the pArrivalInfoList has size
+     * of 6 packets. Hence Out of Memory.
      */
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
@@ -3388,30 +3337,29 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_ArrivalInfoList( void )
     PacketArrivalInfo_t packetArrivalInfo[ 7 ];
     RtcpTwccPacket_t rtcpTwccPacket;
     RtcpResult_t result;
+    uint8_t twccPacketPayload[] =
+    {
+        0x12, 0x34, 0x56, 0x78, /* Sender SSRC. */
+        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC. */
+        0x00, 0x01,             /* Base Sequence Number. */
+        0x00, 0x07,             /* Packet Status Count. */
+        0x00, 0x00, 0x00, 0x02, /* Reference Time (0), Feedback Packet Count (2). */
+        0xE1, 0x01,             /* Status Vector Chunk. */
+        /* Recv delta. */
+        0x80, 0x01,
+        0x01, 0x02
+    };
 
     result = Rtcp_Init( &( context ) );
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
 
-    uint8_t twccPacketPayload[] =
-    {
-        0x12, 0x34, 0x56, 0x78, /* Sender SSRC */
-        0x9A, 0xBC, 0xDE, 0xF0, /* Media Source SSRC */
-        0x00, 0x01,             /* Base Sequence Number */
-        0x00, 0x07,             /* Packet Status Count */
-        0x00, 0x00, 0x00, 0x02, /* Reference Time (0), Feedback Packet Count (2) */
-        0xE1, 0x01,             /* Status Vector Chunk */
-        /* recv delta */
-        0x80, 0x01,
-        0x01, 0x02
-    };
-
     rtcpPacket.pPayload = twccPacketPayload;
     rtcpPacket.payloadLength = sizeof( twccPacketPayload );
     rtcpPacket.header.packetType = RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC;
 
-    rtcpTwccPacket.pArrivalInfoList = &( packetArrivalInfo[ 0 ] );      /* A non NULL arrivalInfo List */
+    rtcpTwccPacket.pArrivalInfoList = &( packetArrivalInfo[ 0 ] ); /* A non NULL arrivalInfo List. */
     rtcpTwccPacket.arrivalInfoListLength = 7;
 
     result = Rtcp_ParseTwccPacket( &( context ),
@@ -3436,7 +3384,7 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_ArrivalInfoList( void )
                        rtcpTwccPacket.arrivalInfoListLength );
     TEST_ASSERT_EQUAL( 0x0001,
                        rtcpTwccPacket.pArrivalInfoList[ 0 ].seqNum );
-    TEST_ASSERT_EQUAL( 293,
+    TEST_ASSERT_EQUAL( 81922500,
                        rtcpTwccPacket.pArrivalInfoList[ 0 ].remoteArrivalTime );
 }
 

--- a/test/unit-test/rtcp_api/rtcp_api_utest.c
+++ b/test/unit-test/rtcp_api/rtcp_api_utest.c
@@ -619,8 +619,10 @@ void test_rtcpDeSerializePacket_UNKOWN( void )
                                      serializedPacketLength,
                                      &( rtcpPacket ) );
 
-    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+    TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_UNKNOWN,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 31,
@@ -674,6 +676,8 @@ void test_rtcpDeSerializePacket_FIR( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_FIR,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 0,
@@ -726,8 +730,10 @@ void test_rtcpDeSerializePacket_FIR_Invalid( void )
                                      serializedPacketLength,
                                      &( rtcpPacket ) );
 
-    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+    TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_UNKNOWN,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 2,
@@ -783,6 +789,8 @@ void test_rtcpDeSerializePacket_SenderReport( void )
                        result );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_SENDER_REPORT,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 2,
                        rtcpPacket.header.receptionReportCount );  /* Feedback message type (FMT) */
     TEST_ASSERT_EQUAL_PTR( &( serializedPacket[ 4 ] ),
@@ -796,7 +804,7 @@ void test_rtcpDeSerializePacket_SenderReport( void )
 /**
  * @brief Validate RTCP DeSerialize Packet functionality.
  */
-void test_rtcpDeSerializePacket_TransportSpecificFeedback( void )
+void test_rtcpDeSerializePacket_TransportSpecificFeedback_Nack( void )
 {
     RtcpContext_t context;
     uint8_t serializedPacket[] =
@@ -834,6 +842,8 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_TRANSPORT_FEEDBACK_NACK,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 1,
@@ -854,7 +864,7 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_TWCC( void )
     RtcpContext_t context;
     uint8_t serializedPacket[] =
     {
-        0x8F, 0xCD, 0x00, 0x0D,  /* Header: V=2, P=0, FMT=15, PT=RR=205, Length = 0xD words. */
+        0x8F, 0xCD, 0x00, 0x0D, /* Header: V=2, P=0, FMT=15, PT=RR=205, Length = 0xD words. */
         0x87, 0x65, 0x43, 0x21, /* Sender SSRC */
         /* Reception Report 1. */
         0x00, 0x00, 0x00, 0x01, /* SSRC of first source. */
@@ -887,6 +897,8 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_TWCC( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_TRANSPORT_FEEDBACK_TWCC,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 15,
@@ -904,6 +916,7 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_TWCC( void )
  */
 void test_rtcpDeSerializePacket_TransportSpecificFeedback_unknown( void )
 {
+    /* Thought The Packet Type is of  Transport Specific Feedback, the Feedback Message Type ( FMT ) is Unknown */
     RtcpContext_t context;
     uint8_t serializedPacket[] =
     {
@@ -938,8 +951,10 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_unknown( void )
                                      serializedPacketLength,
                                      &( rtcpPacket ) );
 
-    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+    TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_UNKNOWN,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 31,
@@ -955,7 +970,7 @@ void test_rtcpDeSerializePacket_TransportSpecificFeedback_unknown( void )
 /**
  * @brief Validate RTCP DeSerialize Packet functionality.
  */
-void test_rtcpDeSerializePacket_PayloadSpecificFeedback_PLI( void )
+void test_rtcpDeSerializePacket_PayloadSpecificFeedback_SLI( void )
 {
     RtcpContext_t context;
     uint8_t serializedPacket[] =
@@ -993,6 +1008,8 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_PLI( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_PAYLOAD_FEEDBACK_SLI,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 2,
@@ -1008,7 +1025,7 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_PLI( void )
 /**
  * @brief Validate RTCP DeSerialize Packet functionality.
  */
-void test_rtcpDeSerializePacket_PayloadSpecificFeedback_SLI( void )
+void test_rtcpDeSerializePacket_PayloadSpecificFeedback_PLI( void )
 {
     RtcpContext_t context;
     uint8_t serializedPacket[] =
@@ -1039,6 +1056,8 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_SLI( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_PAYLOAD_FEEDBACK_PLI,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 1,
@@ -1092,6 +1111,8 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_REMB( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_PAYLOAD_FEEDBACK_REMB,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 15,
@@ -1143,8 +1164,10 @@ void test_rtcpDeSerializePacket_PayloadSpecificFeedback_unknown( void )
                                      serializedPacketLength,
                                      &( rtcpPacket ) );
 
-    TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
+    TEST_ASSERT_EQUAL( RTCP_RESULT_MALFORMED_PACKET,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_UNKNOWN,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 31,
@@ -1198,6 +1221,8 @@ void test_rtcpDeSerializePacket_ReceiverReport( void )
 
     TEST_ASSERT_EQUAL( RTCP_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( RTCP_PACKET_RECEIVER_REPORT,
+                       rtcpPacket.header.packetType );
     TEST_ASSERT_EQUAL( 0,
                        rtcpPacket.header.padding );
     TEST_ASSERT_EQUAL( 2,
@@ -1514,7 +1539,7 @@ void test_rtcpParseSliPacket_NullInfo( void )
      *  Even though in the payload an SLI Info is going, since the rtcpSliPacket has pSliInfos as NULL, no such SLI Info's are retrieved.
      */
     size_t sliPacketPayloadLength = sizeof( sliPacketPayload );
-    
+
 
     result = Rtcp_Init( &( context ) );
 
@@ -2693,7 +2718,7 @@ void test_rtcpParseTwccPacket_BadParams( void )
 /**
  * @brief Validate RTCP Parse Twcc Packet functionality for Run Length with Malformed Small Delta.
  */
-void test_rtcpParseTwccPacket_RunLengthChunk_SMALLDELTA_MALFORMED( void )
+void test_rtcpParseTwccPacket_RunLengthChunk_SmallDelta_Malformed( void )
 {
     RtcpContext_t context;
     RtcpPacket_t rtcpPacket;
@@ -2746,7 +2771,7 @@ void test_rtcpParseTwccPacket_RunLengthChunk_SMALLDELTA_MALFORMED( void )
 /**
  * @brief Validate RTCP Parse Twcc Packet functionality for Run Length with Malformed Big Delta.
  */
-void test_rtcpParseTwccPacket_RunLengthChunk_BIGDELTA_MALFORMED( void )
+void test_rtcpParseTwccPacket_RunLengthChunk_BigDelta_Malformed( void )
 {
     RtcpContext_t context;
     RtcpPacket_t rtcpPacket;
@@ -3052,7 +3077,7 @@ void test_rtcpParseTwccPacket_RunLengthChunk_ReservedPackets( void )
 /**
  * @brief Validate RTCP Parse Twcc Packet functionality for Status Vector Chunk with Malformed Small Delta.
  */
-void test_rtcpParseTwccPacket_StatusVectorChunk_SMALLDELTA_MALFORMED( void )
+void test_rtcpParseTwccPacket_StatusVectorChunk_SmallDelta_Makformed( void )
 {
     RtcpContext_t context;
     RtcpPacket_t rtcpPacket;
@@ -3107,7 +3132,7 @@ void test_rtcpParseTwccPacket_StatusVectorChunk_SMALLDELTA_MALFORMED( void )
 /**
  * @brief Validate RTCP Parse Twcc Packet functionality for Status Vector Chunk with Malformed Big Delta.
  */
-void test_rtcpParseTwccPacket_StatusVectorChunk_BIGDELTA_MALFORMED( void )
+void test_rtcpParseTwccPacket_StatusVectorChunk_BigDelta_Malformed( void )
 {
     RtcpContext_t context;
     RtcpPacket_t rtcpPacket;


### PR DESCRIPTION
### Description of changes:

This PR is for adding final unit tests to improve coverage, by thoroughly testing various RTCP API's . `README.md` was improved as well. Source code for deletion of packets info in TWCC MANAGER was also improved. 
Also, The Unit-Tests are written from start and keeping the format same as the previous written unit-tests of other files. 

The following test cases have been added:
1. `test_rtcpDeSerializePacket_UNKOWN`
2. `test_rtcpDeSerializePacket_FIR`
3. `test_rtcpDeSerializePacket_FIR_Invalid`
4. `test_rtcpDeSerializePacket_SenderReport`
5. `test_rtcpDeSerializePacket_TransportSpecificFeedback`
6. `test_rtcpDeSerializePacket_TransportSpecificFeedback_TWCC`
7. `test_rtcpDeSerializePacket_TransportSpecificFeedback_unknown`
8. `test_rtcpDeSerializePacket_PayloadSpecificFeedback_PLI`
9. `test_rtcpDeSerializePacket_PayloadSpecificFeedback_SLI`
10. `test_rtcpDeSerializePacket_PayloadSpecificFeedback_REMB`
11. `test_rtcpDeSerializePacket_PayloadSpecificFeedback_unknown`
12. `test_rtcpParseSliPacket_NullInfo`
13. `test_rtcpParseTwccPacket_RunLengthChunk_SMALLDELTA_MALFORMED`
14. `test_rtcpParseTwccPacket_RunLengthChunk_BIGDELTA_MALFORMED`
15. `test_rtcpParseTwccPacket_RunLengthChunk_OutOfMemory`
16. `test_rtcpParseTwccPacket_RunLengthChunk_ArrivalInfoList`
17. `test_rtcpParseTwccPacket_RunLengthChunk`
18. `test_rtcpParseTwccPacket_RunLengthChunk_ReservedPackets`
19. `test_rtcpParseTwccPacket_StatusVectorChunk_SMALLDELTA_MALFORMED`
20. `test_rtcpParseTwccPacket_StatusVectorChunk_BIGDELTA_MALFORMED`
21. `test_rtcpParseTwccPacket_StatusVectorChunk_BasicSymbol`
22. `test_rtcpParseTwccPacket_StatusVectorChunk_DetailSymbol`
23. `test_rtcpParseTwccPacket_StatusVectorChunk_OutofMemory`
24. `test_rtcpParseTwccPacket_StatusVectorChunk_ArrivalInfoList`


### Test Steps

```
cmake -S test/unit-test -B build/ -G "Unix Makefiles"  -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
